### PR TITLE
Add support for multiple files in KUBECONFIG

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -506,7 +506,7 @@ impl Config {
         })
     }
 
-    pub fn from_files(paths: &Vec<String>) -> Result<Config, KubeError> {
+    pub fn from_files(paths: &[String]) -> Result<Config, KubeError> {
         let configs = paths
             .into_iter()
             .map(|config_path| {

--- a/src/config.rs
+++ b/src/config.rs
@@ -507,7 +507,10 @@ impl Config {
             }
         }
 
-        let sources = env::join_paths(paths.into_iter())?.into_string()?;
+        let sources = match env::join_paths(paths.into_iter())?.into_string() {
+            Ok(srcs) => srcs,
+            Err(_) => "[config paths contain non-utf8 characters, cannot be displayed]".to_string(),
+        };
 
         Ok(Config {
             source_file: sources,

--- a/src/config.rs
+++ b/src/config.rs
@@ -413,136 +413,108 @@ fn auth_from_data(
 }
 
 impl Config {
-    pub fn from_file(path: &str) -> Result<Config, KubeError> {
-        let iconf = IConfig::from_file(path)?;
+    pub fn from_files(paths: &[String]) -> Result<Config, KubeError> {
+        let iconfs = paths
+            .into_iter()
+            .map(|config_path| IConfig::from_file(config_path))
+            .collect::<Result<Vec<_>,_>>()?;
 
         // copy over clusters
         let mut cluster_map = HashMap::new();
-        for cluster in iconf.clusters.into_iter() {
-            // make sure we've specified one of:
-            //  - a cert file
-            //  - cert data
-            //  - insecure-skip-tls-verify
-            let has_cd = cluster.conf.cert_data.is_some();
-            match (cluster.conf.cert, cluster.conf.cert_data) {
-                (Some(cert_config_path), _) => {
-                    if has_cd {
-                        println!(
-                            "Cluster {} specifies a certificate path and certificate data, \
-                             ignoring data and using the path",
-                            cluster.name
-                        );
+        for iconf in iconfs.iter() {
+            for cluster in iconf.clusters.iter() {
+                // make sure we've specified one of:
+                //  - a cert file
+                //  - cert data
+                //  - insecure-skip-tls-verify
+                let has_cd = cluster.conf.cert_data.is_some();
+                match (&cluster.conf.cert, &cluster.conf.cert_data) {
+                    (Some(cert_config_path), _) => {
+                        if has_cd {
+                            println!(
+                                "Cluster {} specifies a certificate path and certificate data, \
+                                ignoring data and using the path",
+                                cluster.name
+                            );
+                        }
+                        let cert_path = get_full_path(cert_config_path.to_owned())?;
+                        match File::open(cert_path) {
+                            Ok(f) => {
+                                let mut br = BufReader::new(f);
+                                let mut s = String::new();
+                                br.read_to_string(&mut s).expect("Couldn't read cert");
+                                cluster_map.insert(
+                                    cluster.name.clone(),
+                                    ClusterConf::new(Some(s), cluster.conf.server.clone()),
+                                );
+                            }
+                            Err(e) => {
+                                println!(
+                                    "Invalid server cert path for cluster {}: {}.\nAny contexts using \
+                                    this cluster will be unavailable.",
+                                    cluster.name,
+                                    e.description()
+                                );
+                            }
+                        }
                     }
-                    let cert_path = get_full_path(cert_config_path)?;
-                    match File::open(cert_path) {
-                        Ok(f) => {
-                            let mut br = BufReader::new(f);
-                            let mut s = String::new();
-                            br.read_to_string(&mut s).expect("Couldn't read cert");
+                    (None, Some(cert_data)) => match ::base64::decode(cert_data.as_str()) {
+                        Ok(mut cert) => {
+                            cert.retain(|&i| i != 0);
+                            let cert_pem = String::from_utf8(cert).map_err(|e| {
+                                KubeError::ConfigFileError(format!(
+                                    "Invalid utf8 data in certificate: {}",
+                                    e.description()
+                                ))
+                            })?;
                             cluster_map.insert(
                                 cluster.name.clone(),
-                                ClusterConf::new(Some(s), cluster.conf.server),
+                                ClusterConf::new(Some(cert_pem), cluster.conf.server.clone()),
                             );
                         }
                         Err(e) => {
                             println!(
-                                "Invalid server cert path for cluster {}: {}.\nAny contexts using \
-                                 this cluster will be unavailable.",
-                                cluster.name,
+                                "Invalid certificate data, could not base64 decode: {}",
                                 e.description()
                             );
                         }
+                    },
+                    (None, None) => {
+                        let conf = if cluster.conf.skip_tls.unwrap_or(false) {
+                            ClusterConf::new_insecure(None, cluster.conf.server.clone())
+                        } else {
+                            ClusterConf::new(None, cluster.conf.server.clone())
+                        };
+                        cluster_map.insert(cluster.name.clone(), conf);
                     }
-                }
-                (None, Some(cert_data)) => match ::base64::decode(cert_data.as_str()) {
-                    Ok(mut cert) => {
-                        cert.retain(|&i| i != 0);
-                        let cert_pem = String::from_utf8(cert).map_err(|e| {
-                            KubeError::ConfigFileError(format!(
-                                "Invalid utf8 data in certificate: {}",
-                                e.description()
-                            ))
-                        })?;
-                        cluster_map.insert(
-                            cluster.name.clone(),
-                            ClusterConf::new(Some(cert_pem), cluster.conf.server),
-                        );
-                    }
-                    Err(e) => {
-                        println!(
-                            "Invalid certificate data, could not base64 decode: {}",
-                            e.description()
-                        );
-                    }
-                },
-                (None, None) => {
-                    let conf = if cluster.conf.skip_tls.unwrap_or(false) {
-                        ClusterConf::new_insecure(None, cluster.conf.server)
-                    } else {
-                        ClusterConf::new(None, cluster.conf.server)
-                    };
-                    cluster_map.insert(cluster.name.clone(), conf);
                 }
             }
         }
 
         // copy over contexts
         let mut context_map = HashMap::new();
-        for context in iconf.contexts.iter() {
-            context_map.insert(context.name.clone(), context.conf.clone());
+        for iconf in iconfs.iter() {
+            for context in iconf.contexts.iter() {
+                context_map.insert(context.name.clone(), context.conf.clone());
+            }
         }
 
         // copy over users
         let mut user_map = HashMap::new();
-        for user in iconf.users.into_iter() {
-            user_map.insert(user.name.clone(), user.conf.into());
+        for iconf in iconfs.iter() {
+            for user in iconf.users.iter() {
+                user_map.insert(user.name.clone(), user.conf.clone().into());
+            }
         }
 
+        let sources = env::join_paths(paths.into_iter())?.into_string()?;
+
         Ok(Config {
-            source_file: path.to_owned(),
+            source_file: sources,
             clusters: cluster_map,
             contexts: context_map,
             users: user_map,
         })
-    }
-
-    pub fn from_files(paths: &[String]) -> Result<Config, KubeError> {
-        let configs = paths
-            .into_iter()
-            .map(|config_path| {
-                Config::from_file(config_path.as_str())
-                    .map_err(|e| KubeError::ConfigFileError(format!(
-                        "Could not load {}, reason: {}",
-                        config_path, 
-                        e.description()))
-                    )
-            })
-            .collect::<Result<Vec<_>,_>>()?;
-
-        let empty_config = Config{
-            source_file: String::new(),
-            clusters: HashMap::new(),
-            contexts: HashMap::new(),
-            users: HashMap::new(),
-        };
-
-        let mut source_vector = Vec::new();
-        let mut merged_config: Config = configs
-            .into_iter()
-            .fold(empty_config, |mut resulting_config, item| {
-                source_vector.push(item.source_file);
-                resulting_config.clusters.extend(item.clusters);
-                resulting_config.contexts.extend(item.contexts);
-                resulting_config.users.extend(item.users);
-
-                resulting_config
-            });
-
-        let sources = env::join_paths(source_vector.into_iter())?.into_string()?;
-
-        merged_config.source_file = sources;
-
-        Ok(merged_config)
     }
 
     pub fn cluster_for_context(&self, context: &str) -> Result<Kluster, KubeError> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ use hyper;
 use serde_json;
 use serde_yaml;
 
-use std::{error, fmt, io};
+use std::{error, fmt, io, env, ffi};
 use std::convert::From;
 
 #[derive(Debug)]
@@ -74,6 +74,8 @@ pub enum KubeError {
     HyperErr(hyper::error::Error),
     SerdeJson(serde_json::Error),
     SerdeYaml(serde_yaml::Error),
+    JoinPathsError(env::JoinPathsError),
+    OsString(ffi::OsString),
 }
 
 impl fmt::Display for KubeError {
@@ -89,6 +91,8 @@ impl fmt::Display for KubeError {
             KubeError::HyperErr(ref err) => write!(f, "Hyper error: {}", err),
             KubeError::SerdeJson(ref err) => write!(f, "Serde json error: {}", err),
             KubeError::SerdeYaml(ref err) => write!(f, "Serde yaml error: {}", err),
+            KubeError::JoinPathsError(ref err) => write!(f, "Join paths error: {}", err),
+            KubeError::OsString(_) => write!(f, "OsString convert error"),
         }
     }
 }
@@ -106,6 +110,8 @@ impl error::Error for KubeError {
             KubeError::HyperErr(ref err) => err.description(),
             KubeError::SerdeJson(ref err) => err.description(),
             KubeError::SerdeYaml(ref err) => err.description(),
+            KubeError::JoinPathsError(ref err) => err.description(),
+            KubeError::OsString(_) => "OsString contains invalid UTF-8 chars",
         }
     }
 
@@ -121,6 +127,8 @@ impl error::Error for KubeError {
             KubeError::HyperErr(ref err) => Some(err),
             KubeError::SerdeJson(ref err) => Some(err),
             KubeError::SerdeYaml(ref err) => Some(err),
+            KubeError::JoinPathsError(ref err) => Some(err),
+            KubeError::OsString(_) => None,
         }
     }
 }
@@ -158,5 +166,17 @@ impl From<serde_yaml::Error> for KubeError {
 impl From<base64::DecodeError> for KubeError {
     fn from(err: base64::DecodeError) -> KubeError {
         KubeError::DecodeError(err)
+    }
+}
+
+impl From<env::JoinPathsError> for KubeError {
+    fn from(err: env::JoinPathsError) -> KubeError {
+        KubeError::JoinPathsError(err)
+    }
+}
+
+impl From<ffi::OsString> for KubeError {
+    fn from(err: ffi::OsString) -> KubeError {
+        KubeError::OsString(err)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ use hyper;
 use serde_json;
 use serde_yaml;
 
-use std::{error, fmt, io, env, ffi};
+use std::{error, fmt, io, env};
 use std::convert::From;
 
 #[derive(Debug)]
@@ -75,7 +75,6 @@ pub enum KubeError {
     SerdeJson(serde_json::Error),
     SerdeYaml(serde_yaml::Error),
     JoinPathsError(env::JoinPathsError),
-    OsString(ffi::OsString),
 }
 
 impl fmt::Display for KubeError {
@@ -92,7 +91,6 @@ impl fmt::Display for KubeError {
             KubeError::SerdeJson(ref err) => write!(f, "Serde json error: {}", err),
             KubeError::SerdeYaml(ref err) => write!(f, "Serde yaml error: {}", err),
             KubeError::JoinPathsError(ref err) => write!(f, "Join paths error: {}", err),
-            KubeError::OsString(_) => write!(f, "OsString convert error"),
         }
     }
 }
@@ -111,7 +109,6 @@ impl error::Error for KubeError {
             KubeError::SerdeJson(ref err) => err.description(),
             KubeError::SerdeYaml(ref err) => err.description(),
             KubeError::JoinPathsError(ref err) => err.description(),
-            KubeError::OsString(_) => "OsString contains invalid UTF-8 chars",
         }
     }
 
@@ -128,7 +125,6 @@ impl error::Error for KubeError {
             KubeError::SerdeJson(ref err) => Some(err),
             KubeError::SerdeYaml(ref err) => Some(err),
             KubeError::JoinPathsError(ref err) => Some(err),
-            KubeError::OsString(_) => None,
         }
     }
 }
@@ -172,11 +168,5 @@ impl From<base64::DecodeError> for KubeError {
 impl From<env::JoinPathsError> for KubeError {
     fn from(err: env::JoinPathsError) -> KubeError {
         KubeError::JoinPathsError(err)
-    }
-}
-
-impl From<ffi::OsString> for KubeError {
-    fn from(err: ffi::OsString) -> KubeError {
-        KubeError::OsString(err)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -562,28 +562,29 @@ fn main() {
     click_path.push("click.config");
     let click_conf = ClickConfig::from_file(click_path.as_path().to_str().unwrap());
 
-    let config_path = env::var_os("KUBECONFIG")
-        .map(|p| PathBuf::from(p))
+    let config_paths = env::var_os("KUBECONFIG")
+        .map(|paths| {
+            let split_paths = env::split_paths(&paths);
+            split_paths.collect::<Vec<PathBuf>>()
+        })
         .unwrap_or_else(|| {
             let mut config_path = conf_dir.clone();
             config_path.push("config");
-            config_path
-        });
-
-    let config = match Config::from_file(
-        config_path
+            vec!(config_path)
+        })
+        .into_iter()
+        .map(|config_file| config_file
             .as_path()
             .to_str()
-            .unwrap_or("[CONFIG_PATH_EMPTY"),
-    ) {
+            .unwrap_or("[CONFIG_PATH_EMPTY")
+            .to_owned())
+        .collect::<Vec<_>>();
+
+    let config = match Config::from_files(&config_paths) {
         Ok(c) => c,
         Err(e) => {
             println!(
-                "Could not load kubernetes config: '{}'. Cannot continue.  Error was: {}",
-                config_path
-                    .as_path()
-                    .to_str()
-                    .unwrap_or("[CONFIG_PATH_EMPTY"),
+                "Could not load kubernetes config. Cannot continue.  Error was: {}",
                 e.description()
             );
             return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -425,7 +425,7 @@ impl fmt::Display for Env {
             "Env {{
   Current Context: {}
   Availble Contexts: {:?}
-  Kubernetes Config File: {}
+  Kubernetes Config File(s): {}
   Editor: {}
   Terminal: {}
 }}",
@@ -576,7 +576,7 @@ fn main() {
         .map(|config_file| config_file
             .as_path()
             .to_str()
-            .unwrap_or("[CONFIG_PATH_EMPTY")
+            .unwrap_or("[CONFIG_PATH_EMPTY]")
             .to_owned())
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
Hi there,

let me start by saying that you have a very nice project here.
I've been enjoying using it for couple of the last days, however the lack of support for multiple files in `KUBECONFIG` makes it pretty usable for me.

I've been playing around with it a bit and decided to hack together a simple support for multiple files (addressing #49).

What I'm doing here is that I'm processing all paths in `KUBECONFIG` into separate `config::Config` structs and then merging them into a single one that is then fed into the environment.
The source_file field is merged using OS specific path separators.
While merging of the other fields is done by simple map extending.

I've tested it with my workflow and it worked flawlessly, but I can image the change might break something I've not tested.
 
Let me know what you think, I'm open to any suggestions.
