### PR TITLE
Add one-off command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -620,6 +620,7 @@ fn main() {
     commands.push(Box::new(cmd::Secrets::new()));
     commands.push(Box::new(cmd::PortForward::new()));
     commands.push(Box::new(cmd::PortForwards::new()));
+    commands.push(Box::new(cmd::OneOff::new()));
 
     let mut rl = Editor::<ClickCompleter>::new();
     rl.load_history(hist_path.as_path()).unwrap_or_default();


### PR DESCRIPTION
This command takes the image of the container of the current pod
and runs the specified command in a one-off kubectl run command.

If the pod has multiple containers and none is specified, it will
fail asking for the specific container.