### PR TITLE
Add jobs support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -506,7 +506,7 @@ impl Config {
         })
     }
 
-    pub fn from_files(paths: &Vec<String>) -> Result<Config, KubeError> {
+    pub fn from_files(paths: &[String]) -> Result<Config, KubeError> {
         let configs = paths
             .into_iter()
             .map(|config_path| {

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ use hyper;
 use serde_json;
 use serde_yaml;
 
-use std::{error, fmt, io};
+use std::{error, fmt, io, env, ffi};
 use std::convert::From;
 
 #[derive(Debug)]
@@ -74,6 +74,8 @@ pub enum KubeError {
     HyperErr(hyper::error::Error),
     SerdeJson(serde_json::Error),
     SerdeYaml(serde_yaml::Error),
+    JoinPathsError(env::JoinPathsError),
+    OsString(ffi::OsString),
 }
 
 impl fmt::Display for KubeError {
@@ -89,6 +91,8 @@ impl fmt::Display for KubeError {
             KubeError::HyperErr(ref err) => write!(f, "Hyper error: {}", err),
             KubeError::SerdeJson(ref err) => write!(f, "Serde json error: {}", err),
             KubeError::SerdeYaml(ref err) => write!(f, "Serde yaml error: {}", err),
+            KubeError::JoinPathsError(ref err) => write!(f, "Join paths error: {}", err),
+            KubeError::OsString(_) => write!(f, "OsString convert error"),
         }
     }
 }
@@ -106,6 +110,8 @@ impl error::Error for KubeError {
             KubeError::HyperErr(ref err) => err.description(),
             KubeError::SerdeJson(ref err) => err.description(),
             KubeError::SerdeYaml(ref err) => err.description(),
+            KubeError::JoinPathsError(ref err) => err.description(),
+            KubeError::OsString(_) => "OsString contains invalid UTF-8 chars",
         }
     }
 
@@ -121,6 +127,8 @@ impl error::Error for KubeError {
             KubeError::HyperErr(ref err) => Some(err),
             KubeError::SerdeJson(ref err) => Some(err),
             KubeError::SerdeYaml(ref err) => Some(err),
+            KubeError::JoinPathsError(ref err) => Some(err),
+            KubeError::OsString(_) => None,
         }
     }
 }
@@ -158,5 +166,17 @@ impl From<serde_yaml::Error> for KubeError {
 impl From<base64::DecodeError> for KubeError {
     fn from(err: base64::DecodeError) -> KubeError {
         KubeError::DecodeError(err)
+    }
+}
+
+impl From<env::JoinPathsError> for KubeError {
+    fn from(err: env::JoinPathsError) -> KubeError {
+        KubeError::JoinPathsError(err)
+    }
+}
+
+impl From<ffi::OsString> for KubeError {
+    fn from(err: ffi::OsString) -> KubeError {
+        KubeError::OsString(err)
     }
 }

--- a/src/kube.rs
+++ b/src/kube.rs
@@ -327,6 +327,24 @@ pub struct SecretList {
     pub items: Vec<Value>,
 }
 
+// Jobs
+#[derive(Debug, Deserialize)]
+pub struct JobSpec {
+    pub parallelism: u32,
+    pub completions: u32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Job {
+    pub metadata: Metadata,
+    pub spec: JobSpec,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct JobList {
+    pub items: Vec<Job>,
+}
+
 // Kubernetes authentication data
 
 // Auth is either a token, a username/password, or a cert and key

--- a/src/main.rs
+++ b/src/main.rs
@@ -562,28 +562,29 @@ fn main() {
     click_path.push("click.config");
     let click_conf = ClickConfig::from_file(click_path.as_path().to_str().unwrap());
 
-    let config_path = env::var_os("KUBECONFIG")
-        .map(|p| PathBuf::from(p))
+    let config_paths = env::var_os("KUBECONFIG")
+        .map(|paths| {
+            let split_paths = env::split_paths(&paths);
+            split_paths.collect::<Vec<PathBuf>>()
+        })
         .unwrap_or_else(|| {
             let mut config_path = conf_dir.clone();
             config_path.push("config");
-            config_path
-        });
-
-    let config = match Config::from_file(
-        config_path
+            vec!(config_path)
+        })
+        .into_iter()
+        .map(|config_file| config_file
             .as_path()
             .to_str()
-            .unwrap_or("[CONFIG_PATH_EMPTY"),
-    ) {
+            .unwrap_or("[CONFIG_PATH_EMPTY")
+            .to_owned())
+        .collect::<Vec<_>>();
+
+    let config = match Config::from_files(&config_paths) {
         Ok(c) => c,
         Err(e) => {
             println!(
-                "Could not load kubernetes config: '{}'. Cannot continue.  Error was: {}",
-                config_path
-                    .as_path()
-                    .to_str()
-                    .unwrap_or("[CONFIG_PATH_EMPTY"),
+                "Could not load kubernetes config. Cannot continue.  Error was: {}",
                 e.description()
             );
             return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ use completer::ClickCompleter;
 use config::{ClickConfig, Config};
 use error::KubeError;
 use kube::{ConfigMapList, DeploymentList, Kluster, NodeList, PodList, ReplicaSetList, SecretList,
-           ServiceList};
+           ServiceList, JobList};
 use output::ClickWriter;
 use values::val_str_opt;
 use std::env;
@@ -102,6 +102,7 @@ enum KObj {
     ReplicaSet(String),
     ConfigMap(String),
     Secret(String),
+    Job(String),
 }
 
 enum LastList {
@@ -113,6 +114,7 @@ enum LastList {
     ReplicaSetList(ReplicaSetList),
     ConfigMapList(ConfigMapList),
     SecretList(SecretList),
+    JobList(JobList),
 }
 
 /// An ongoing port forward
@@ -202,6 +204,7 @@ impl Env {
                 KObj::ReplicaSet(ref name) => Green.bold().paint(name.as_str()),
                 KObj::ConfigMap(ref name) => Black.bold().paint(name.as_str()),
                 KObj::Secret(ref name) => Red.bold().paint(name.as_str()),
+                KObj::Job(ref name) => Purple.bold().paint(name.as_str()),
             }
         );
     }
@@ -353,6 +356,14 @@ impl Env {
                             self.current_object = KObj::None;
                         }
                     }
+                } else {
+                    self.current_object = KObj::None;
+                }
+            },
+            LastList::JobList(ref jl) => {
+                if let Some(dep) = jl.items.get(num) {
+                    self.current_object = KObj::Job(dep.metadata.name.clone());
+                    self.current_object_namespace = dep.metadata.namespace.clone();
                 } else {
                     self.current_object = KObj::None;
                 }
@@ -621,6 +632,7 @@ fn main() {
     commands.push(Box::new(cmd::Secrets::new()));
     commands.push(Box::new(cmd::PortForward::new()));
     commands.push(Box::new(cmd::PortForwards::new()));
+    commands.push(Box::new(cmd::Jobs::new()));
 
     let mut rl = Editor::<ClickCompleter>::new();
     rl.load_history(hist_path.as_path()).unwrap_or_default();


### PR DESCRIPTION
Added basic support for jobs command, addressing #67. 

It follows the code for deployments command with the exception of displaying job relevant data.

It builds on my previous contribution #63 so that might not be desired.
