### PR TITLE
Make config write atomic, and write it more often

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomicwrites"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +169,7 @@ name = "click"
 version = "0.3.2"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atomicwrites 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -993,6 +1004,7 @@ dependencies = [
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
+"checksum atomicwrites 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a3420b33cdefd3feb223dddc23739fc05cc034eb0f2be792c763e3d89e1eb6e3"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727"
 "checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ travis-ci = { repository = "databricks/click" }
 
 [dependencies]
 ansi_term = "0.9"
+atomicwrites = "0.2.2"
 base64 = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2.22"
 ctrlc = "3.0"
 der-parser = "0.3"
+dirs = "1.0.4"
 duct = "^0.11"
 duct_sh = "^0.1"
 humantime = "1.0"
@@ -40,4 +42,3 @@ tempdir = "^0.3"
 term = "^0.4"
 untrusted = "^0.6"
 webpki = "^0.18"
-dirs = "1.0.4"


### PR DESCRIPTION
It sucks to loose your aliases because click was killed for some reason.  This PR makes it so that any time you add/remove and alias, or change context, the config file is written out.

It also makes it so writing the config is atomic (using the `atomicfile` crate), so it's safe to do this from multiple running instances of Click.