### PR TITLE
Make travis run fmt and clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,16 @@ rust:
 os:
   - linux
   - osx
+before_install:
+  - set -e
+  - rustup component add rustfmt
+  - rustup component add clippy
+  - cargo fmt -- --check
+  - rustup self update
+script:
+  - cargo fmt -- --check
+  - cargo clippy -- -D clippy:all
+  - cargo test --verbose
 matrix:
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+cache: cargo
 rust:
   - stable
   - beta
@@ -6,17 +7,29 @@ rust:
 os:
   - linux
   - osx
+env:
+  global:
+  - RUST_BACKTRACE=1
 before_install:
   - set -e
-  - rustup component add rustfmt
-  - rustup component add clippy
-  - cargo fmt -- --check
   - rustup self update
 script:
-  - cargo fmt -- --check
-  - cargo clippy -- -D warnings
+  - cargo build --verbose
   - cargo test --verbose
 matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
+  include:
+  - name: 'cargo fmt check'
+    rust: stable
+    install:
+    - rustup component add rustfmt
+    script:
+    - cargo fmt -- --check
+  - name: 'clippy check'
+    rust: stable
+    install:
+    - rustup component add clippy
+    script:
+    - cargo clippy -- -D warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - rustup self update
 script:
   - cargo fmt -- --check
-  - cargo clippy -- -D clippy:all
+  - cargo clippy -- -D all
   - cargo test --verbose
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - rustup self update
 script:
   - cargo fmt -- --check
-  - cargo clippy -- -D all
+  - cargo clippy -- -D warnings
   - cargo test --verbose
 matrix:
   allow_failures:

--- a/src/config/kubefile.rs
+++ b/src/config/kubefile.rs
@@ -175,9 +175,9 @@ impl AuthProvider {
     fn is_expired(&self) -> bool {
         let expiry = self.expiry.borrow();
         match *expiry {
-            Some(ref e) => {
+            Some(e) => {
                 let now = Local::now();
-                e < &now
+                e < now
             }
             None => {
                 eprintln!("No expiry, cannot validate if token is still valid, assuming expired");

--- a/src/main.rs
+++ b/src/main.rs
@@ -709,6 +709,7 @@ associated editor.
 - 'vi' Hit ESC while editing to edit the line using common vi keybindings (do: 'set edit_mode vi')
 - 'emacs' Use standard readline/bash/emacs keybindings (do: 'set edit_mode emacs')";
 
+#[allow(clippy::cognitive_complexity)]
 fn main() {
     // Command line arg paring for click itself
     let matches = App::new("Click")


### PR DESCRIPTION
Adds rules to .travis.yaml to run tests for cargo fmt and cargo clippy