### PR TITLE
Add connect timeout, make read/connect timeouts configurable

### DIFF
--- a/src/config/click.rs
+++ b/src/config/click.rs
@@ -95,6 +95,14 @@ fn default_range_sep() -> String {
     "--- {name} ---".to_string()
 }
 
+fn default_connect_timeout() -> u32 {
+    10
+}
+
+fn default_read_timeout() -> u32 {
+    20
+}
+
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct ClickConfig {
     pub namespace: Option<String>,
@@ -109,6 +117,11 @@ pub struct ClickConfig {
     pub aliases: Vec<Alias>,
     #[serde(default = "default_range_sep")]
     pub range_separator: String,
+
+    #[serde(default = "default_connect_timeout")]
+    pub connect_timeout_secs: u32,
+    #[serde(default = "default_read_timeout")]
+    pub read_timeout_secs: u32,
 }
 
 impl ClickConfig {
@@ -185,6 +198,8 @@ aliases:
         let a = config.aliases.get(0).unwrap();
         assert_eq!(a.alias, "pn");
         assert_eq!(a.expanded, "pods --sort node");
+        assert_eq!(config.connect_timeout_secs, default_connect_timeout());
+        assert_eq!(config.read_timeout_secs, default_read_timeout());
     }
 
     #[test]

--- a/src/config/kube.rs
+++ b/src/config/kube.rs
@@ -23,6 +23,7 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 
 use certs::{get_cert, get_cert_from_pem, get_key_from_str, get_private_key};
+use config::ClickConfig;
 use error::{KubeErrNo, KubeError};
 use kube::{ClientCertKey, Kluster, KlusterAuth};
 
@@ -314,7 +315,11 @@ impl Config {
         })
     }
 
-    pub fn cluster_for_context(&self, context_name: &str) -> Result<Kluster, KubeError> {
+    pub fn cluster_for_context(
+        &self,
+        context_name: &str,
+        click_conf: &ClickConfig,
+    ) -> Result<Kluster, KubeError> {
         let context = self
             .contexts
             .get(context_name)
@@ -376,6 +381,8 @@ impl Config {
             auth,
             client_cert_key,
             cluster.insecure_skip_tls_verify,
+            click_conf.connect_timeout_secs,
+            click_conf.read_timeout_secs,
         )
     }
 }

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -52,7 +52,7 @@ impl<S: SslClient> ClickSslConnector<S> {
         ClickSslConnector {
             ssl,
             host_addr: self.host_addr.clone(),
-            connect_timeout: self.connect_timeout.clone(),
+            connect_timeout: self.connect_timeout,
         }
     }
 

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -19,7 +19,8 @@
 // passthrough.
 
 use std::io;
-use std::net::TcpStream;
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::Duration;
 
 use hyper::error::Result;
 use hyper::net::{HttpStream, HttpsStream, NetworkConnector, SslClient};
@@ -27,14 +28,23 @@ use hyper::net::{HttpStream, HttpsStream, NetworkConnector, SslClient};
 pub struct ClickSslConnector<S: SslClient> {
     ssl: S,
     host_addr: Option<(String, String)>,
+    connect_timeout: Duration,
 }
 
 impl<S: SslClient> ClickSslConnector<S> {
     /// Create a new connector using the provided SSL implementation.  host_addr should be a tuple
     /// of (hostname,ip_address), and for that hostname we will short-circuit DNS and just map to
     /// the specified IP.
-    pub fn new(s: S, host_addr: Option<(String, String)>) -> ClickSslConnector<S> {
-        ClickSslConnector { ssl: s, host_addr }
+    pub fn new(
+        s: S,
+        host_addr: Option<(String, String)>,
+        connect_timeout: Duration,
+    ) -> ClickSslConnector<S> {
+        ClickSslConnector {
+            ssl: s,
+            host_addr,
+            connect_timeout,
+        }
     }
 
     /// Make a copy of this connector with a new tlsclient
@@ -42,6 +52,7 @@ impl<S: SslClient> ClickSslConnector<S> {
         ClickSslConnector {
             ssl,
             host_addr: self.host_addr.clone(),
+            connect_timeout: self.connect_timeout.clone(),
         }
     }
 
@@ -56,13 +67,20 @@ impl<S: SslClient> ClickSslConnector<S> {
             }
             None => (host, port),
         };
-        Ok(match scheme {
-            "http" => Ok(HttpStream(TcpStream::connect(&addr)?)),
-            _ => Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "Invalid scheme for Http",
-            )),
-        }?)
+        let addrs = addr.to_socket_addrs()?;
+        let mut last_err = io::Error::new(io::ErrorKind::InvalidInput, "Invalid scheme for Http");
+        match scheme {
+            "http" => {
+                for addr in addrs {
+                    match TcpStream::connect_timeout(&addr, self.connect_timeout) {
+                        Ok(stream) => return Ok(HttpStream(stream)),
+                        Err(e) => last_err = e,
+                    }
+                }
+                Err(last_err.into())
+            }
+            _ => Err(last_err.into()),
+        }
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -156,7 +156,7 @@ impl Env {
 
     pub fn set_context(&mut self, ctx: Option<&str>) {
         if let Some(cname) = ctx {
-            self.kluster = match self.config.cluster_for_context(cname) {
+            self.kluster = match self.config.cluster_for_context(cname, &self.click_config) {
                 Ok(k) => Some(k),
                 Err(e) => {
                     println!(

--- a/src/kube.rs
+++ b/src/kube.rs
@@ -589,6 +589,7 @@ impl Kluster {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: &str,
         cert_opt: Option<String>,


### PR DESCRIPTION
Adds new config options `read_timeout_secs` and `connect_timeout_secs` to allow configuring how long click should wait to read/write data, and how long to timeout after when trying to connect to a host.