### PR TITLE
Add describe for deployment

### DIFF
--- a/src/describe.rs
+++ b/src/describe.rs
@@ -120,10 +120,7 @@ where
                 ref path,
                 ref default,
             } => val_str(path, v, default),
-            DescItem::Valu64 {
-                ref path,
-                default,
-            } => val_u64(path, v, default).to_string().into(),
+            DescItem::Valu64 { ref path, default } => val_u64(path, v, default).to_string().into(),
             DescItem::KeyValStr {
                 ref parent,
                 secret_vals,
@@ -605,9 +602,15 @@ fn get_container_str(v: &Value) -> Cow<str> {
     let mut buf = String::new();
     if let Some(container_array) = v.as_array() {
         for container in container_array.iter() {
-            buf.push_str(format!("  Name: {}\n", val_str("/name", container, "<No Name>")).as_str());
             buf.push_str(
-                format!("    Image:\t{}\n", val_str("/image", container, "<No Image>")).as_str(),
+                format!("  Name: {}\n", val_str("/name", container, "<No Name>")).as_str(),
+            );
+            buf.push_str(
+                format!(
+                    "    Image:\t{}\n",
+                    val_str("/image", container, "<No Image>")
+                )
+                .as_str(),
             );
         }
     }

--- a/src/kobj.rs
+++ b/src/kobj.rs
@@ -164,6 +164,9 @@ impl KObj {
                         ObjType::Node => {
                             clickwriteln!(writer, "{}", describe::describe_format_node(val))
                         }
+                        ObjType::Deployment => {
+                            clickwriteln!(writer, "{}", describe::describe_format_deployment(val))
+                        }
                         ObjType::Secret => {
                             clickwriteln!(writer, "{}", describe::describe_format_secret(val))
                         }


### PR DESCRIPTION
Rudimentary `describe` for deployments. (and also added `DescItem::Valu64` in the process)

```
[dev] [default] [2 Deployments selected] > describe
--- alertmanager ---
Name:           alertmanager
Namespace:      default
Created at:     2016-09-24 04:23:54 UTC (2016-09-23 23:23:54 -05:00)
Generation:     47
Labels:         app=alertmanager
Desired Replicas:       1
Current Replicas:       1
Up To Date Replicas:    1
Available Replicas:     1

Containers:
  Name: prometheus-config-watcher
    Image:      registry.dev.databricks.com/universe/prometheus-config-watcher:0.6
  Name: alertmanager
    Image:      prom/alertmanager:v0.19.0

Messages:
  Message: Deployment has minimum availability.


--- metrics-search ---
Name:           metrics-search
Namespace:      default
Created at:     2018-09-14 22:07:15 UTC (2018-09-14 17:07:15 -05:00)
Generation:     4
Labels:         app=metrics-search
                project=metrics-search
Desired Replicas:       1
Current Replicas:       1
Up To Date Replicas:    1
Available Replicas:     1

Containers:
  Name: metrics-search
    Image:      registry.dev.databricks.com/universe/metrics-search:latest
  Name: auth-proxy
    Image:      registry.dev.databricks.com/oauth2_proxy:7eb7e0b95666b4c026270d4a8723c1aeb0309410-20170625-231803

Messages:
  Message: Deployment has minimum availability.

```