### PR TITLE
Tab-complete Kubernetes context in alphabetical order.

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -104,7 +104,7 @@ fn exec_match<F>(
     func: F,
 ) -> bool
 where
-    F: FnOnce(ArgMatches, &mut Env, &mut ClickWriter) -> (),
+    F: FnOnce(ArgMatches, &mut Env, &mut ClickWriter),
 {
     // TODO: Should be able to not clone and use get_matches_from_safe_borrow, but
     // that causes weird errors involving conflicting arguments being used
@@ -3095,10 +3095,10 @@ Examples:
                 clickwriteln!(writer, "Forwarding port(s): {}", pvec.join(", "));
 
                 env.add_port_forward(env::PortForward {
-                    child: child,
-                    pod: pod,
+                    child,
+                    pod,
                     ports: pvec,
-                    output: output,
+                    output,
                 });
             }
             Err(e) => match e.kind() {

--- a/src/config/kube.rs
+++ b/src/config/kube.rs
@@ -16,6 +16,7 @@
 //! so on.  Data in here is what gets passed around to the rest of Click.
 
 use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::convert::From;
 use std::env;
 use std::fs::File;
@@ -106,7 +107,7 @@ impl From<super::kubefile::UserConf> for UserConf {
 pub struct Config {
     pub source_file: String,
     pub clusters: HashMap<String, ClusterConf>,
-    pub contexts: HashMap<String, super::kubefile::ContextConf>,
+    pub contexts: BTreeMap<String, super::kubefile::ContextConf>,
     pub users: HashMap<String, UserConf>,
 }
 
@@ -278,7 +279,7 @@ impl Config {
         }
 
         // copy over contexts
-        let mut context_map = HashMap::new();
+        let mut context_map = BTreeMap::new();
         for iconf in iconfs.iter() {
             for context in iconf.contexts.iter() {
                 context_map.insert(context.name.clone(), context.conf.clone());
@@ -381,13 +382,13 @@ impl Config {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     pub fn get_test_config() -> Config {
         Config {
             source_file: "/tmp/test.conf".to_string(),
             clusters: HashMap::new(),
-            contexts: HashMap::new(),
+            contexts: BTreeMap::new(),
             users: HashMap::new(),
         }
     }

--- a/src/config/kube.rs
+++ b/src/config/kube.rs
@@ -15,8 +15,8 @@
 //! Code to represent the data found in .kube/config files after it's deserialized, validated, and
 //! so on.  Data in here is what gets passed around to the rest of Click.
 
-use std::collections::HashMap;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::convert::From;
 use std::env;
 use std::fs::File;

--- a/src/env.rs
+++ b/src/env.rs
@@ -10,7 +10,7 @@ use ansi_term::Colour::{Blue, Green, Red, Yellow};
 use rustyline::config as rustyconfig;
 use tempdir::TempDir;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::path::PathBuf;
 use std::process::Child;
@@ -150,7 +150,7 @@ impl Env {
         self.click_config.get_rustyline_conf()
     }
 
-    pub fn get_contexts(&self) -> &HashMap<String, ::config::ContextConf> {
+    pub fn get_contexts(&self) -> &BTreeMap<String, ::config::ContextConf> {
         &self.config.contexts
     }
 


### PR DESCRIPTION
The `HashMap` order is arbitrary, but it's kind of nice to have tab-completion proceed in alphabetical order.

![render1598295464052](https://user-images.githubusercontent.com/63264495/91085141-fc9e6a80-e61a-11ea-89a8-c4006cde8a22.gif)
