### PR TITLE
Allow tab completions for specific options

### DIFF
--- a/src/certs.rs
+++ b/src/certs.rs
@@ -138,9 +138,8 @@ pub fn get_key_from_str(s: &str) -> Option<PrivateKey> {
                                 Some(oid) => {
                                     if let der_parser::DerObjectContent::OID(ref v) = oid.content {
                                         if *v == RSAOID {
-                                            if let der_parser::DerObjectContent::OctetString(
-                                                v,
-                                            ) = bits.content
+                                            if let der_parser::DerObjectContent::OctetString(v) =
+                                                bits.content
                                             {
                                                 validate_private_key(PrivateKey(v.to_vec()))
                                             } else {

--- a/src/certs.rs
+++ b/src/certs.rs
@@ -33,17 +33,16 @@ use std::time::Duration;
 pub fn get_cert(path: &str) -> Option<Certificate> {
     let inpath = Path::new(path);
     let cert_file = File::open(inpath).unwrap();
+    let mut cert_br = BufReader::new(cert_file);
     if inpath.extension().unwrap() == "der" {
         // with .der, just read and return
-        let mut cert_br = BufReader::new(cert_file);
         let mut cert_buf = Vec::new();
         cert_br.read_to_end(&mut cert_buf).unwrap();
         Some(Certificate(cert_buf))
     } else {
         // assume it's not a der and is a pem and try and convert
-        let mut pem_br = BufReader::new(cert_file);
         let mut pem_buf = String::new();
-        match pem_br.read_to_string(&mut pem_buf) {
+        match cert_br.read_to_string(&mut pem_buf) {
             Ok(_) => get_cert_from_pem(pem_buf.as_str()),
             Err(e) => {
                 println!("Error reading cert {}: {}", path, e);
@@ -140,7 +139,7 @@ pub fn get_key_from_str(s: &str) -> Option<PrivateKey> {
                                     if let der_parser::DerObjectContent::OID(ref v) = oid.content {
                                         if *v == RSAOID {
                                             if let der_parser::DerObjectContent::OctetString(
-                                                ref v,
+                                                v,
                                             ) = bits.content
                                             {
                                                 validate_private_key(PrivateKey(v.to_vec()))

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -256,7 +256,7 @@ macro_rules! command {
                     .filter(|fb| completer::long_matches(&fb.s.long, prefix))
                     .map(|fb| RustlinePair {
                         display: format!("--{}", fb.s.long.unwrap()),
-                        replacement: fb.s.long.unwrap()[repoff..].to_string(),
+                        replacement: format!("{} ", fb.s.long.unwrap()[repoff..].to_string()),
                     });
 
                 let opts = parser
@@ -265,7 +265,7 @@ macro_rules! command {
                     .filter(|ob| completer::long_matches(&ob.s.long, prefix))
                     .map(|ob| RustlinePair {
                         display: format!("--{}", ob.s.long.unwrap()),
-                        replacement: ob.s.long.unwrap()[repoff..].to_string(),
+                        replacement: format!("{} ", ob.s.long.unwrap()[repoff..].to_string()),
                     });
 
                 flags.chain(opts).collect()

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -51,7 +51,7 @@ use std::cell::RefCell;
 use std::cmp;
 use std::collections::HashMap;
 use std::io::{self, stderr, BufRead, BufReader, Read, Write};
-use std::iter::{FromIterator, Iterator};
+use std::iter::Iterator;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::atomic::Ordering;
@@ -1912,10 +1912,11 @@ command!(
         ),
     vec!["exec"],
     noop_complete!(),
-    HashMap::<String, fn(&str, &Env) -> Vec<RustlinePair>>::from_iter(IntoIter::new([(
+    IntoIter::new([(
         "container".to_string(),
         completer::container_completer as fn(&str, &Env) -> Vec<RustlinePair>
-    )])),
+    )])
+    .collect(),
     |matches, env, writer| {
         let cmd = matches.value_of("command").unwrap(); // safe as required
         if let Some(ref kluster) = env.kluster.as_ref() {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -72,8 +72,13 @@ lazy_static! {
 
 pub trait Cmd {
     // break if returns true
-    fn exec(&self, &mut Env, &mut dyn Iterator<Item = &str>, &mut ClickWriter) -> bool;
-    fn is(&self, &str) -> bool;
+    fn exec(
+        &self,
+        env: &mut Env,
+        args: &mut dyn Iterator<Item = &str>,
+        writer: &mut ClickWriter,
+    ) -> bool;
+    fn is(&self, l: &str) -> bool;
     fn get_name(&self) -> &'static str;
     fn try_complete(&self, index: usize, prefix: &str, env: &Env) -> Vec<RustlinePair>;
     fn try_completed_named(

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -486,7 +486,7 @@ fn create_podlist_specs<'a>(
         .status
         .container_statuses
         .as_ref()
-        .map(|stats| stats.iter().fold(0, |acc, ref x| acc + x.restart_count))
+        .map(|stats| stats.iter().fold(0, |acc, x| acc + x.restart_count))
         .unwrap_or(0);
     specs.push(CellSpec::new_owned(format!("{}", restarts)));
 
@@ -593,13 +593,13 @@ fn print_podlist(
                     .status
                     .container_statuses
                     .as_ref()
-                    .map(|stats| stats.iter().fold(0, |acc, ref x| acc + x.restart_count))
+                    .map(|stats| stats.iter().fold(0, |acc, x| acc + x.restart_count))
                     .unwrap_or(0);
                 let p2r = p2
                     .status
                     .container_statuses
                     .as_ref()
-                    .map(|stats| stats.iter().fold(0, |acc, ref x| acc + x.restart_count))
+                    .map(|stats| stats.iter().fold(0, |acc, x| acc + x.restart_count))
                     .unwrap_or(0);
                 p1r.partial_cmp(&p2r).unwrap()
             }),
@@ -1928,7 +1928,7 @@ command!(
     .collect(),
     |matches, env, writer| {
         let cmd = matches.value_of("command").unwrap(); // safe as required
-        if let Some(ref kluster) = env.kluster.as_ref() {
+        if let Some(kluster) = env.kluster.as_ref() {
             let tty = if matches.is_present("tty") {
                 if let Some(v) = matches.value_of("tty") {
                     // already validated

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1351,7 +1351,11 @@ command!(
         ),
     vec!["pods"],
     noop_complete!(),
-    no_named_complete!(),
+    IntoIter::new([(
+        "sort".to_string(),
+        completer::pod_sort_values_completer as fn(&str, &Env) -> Vec<RustlinePair>
+    )])
+    .collect(),
     |matches, env, writer| {
         let regex = match ::table::get_regex(&matches) {
             Ok(r) => r,
@@ -2346,7 +2350,11 @@ command!(
         ),
     vec!["nodes"],
     noop_complete!(),
-    no_named_complete!(),
+    IntoIter::new([(
+        "sort".to_string(),
+        completer::node_sort_values_completer as fn(&str, &Env) -> Vec<RustlinePair>
+    )])
+    .collect(),
     |matches, env, writer| {
         let regex = match ::table::get_regex(&matches) {
             Ok(r) => r,
@@ -2429,7 +2437,11 @@ command!(
         ),
     vec!["services"],
     noop_complete!(),
-    no_named_complete!(),
+    IntoIter::new([(
+        "sort".to_string(),
+        completer::service_sort_values_completer as fn(&str, &Env) -> Vec<RustlinePair>
+    )])
+    .collect(),
     |matches, env, writer| {
         let regex = match ::table::get_regex(&matches) {
             Ok(r) => r,
@@ -2628,7 +2640,11 @@ command!(
         ),
     vec!["deps", "deployments"],
     noop_complete!(),
-    no_named_complete!(),
+    IntoIter::new([(
+        "sort".to_string(),
+        completer::deployment_sort_values_completer as fn(&str, &Env) -> Vec<RustlinePair>
+    )])
+    .collect(),
     |matches, env, writer| {
         let regex = match ::table::get_regex(&matches) {
             Ok(r) => r,

--- a/src/command_processor.rs
+++ b/src/command_processor.rs
@@ -356,7 +356,11 @@ impl CommandProcessor {
                         clickwriteln!(writer, "{}", RANGEHELP);
                     }
                     _ => {
-                        clickwriteln!(writer, "I don't know anything about {}, sorry", hcmd);
+                        if let Some(alias) = self.env.get_alias(hcmd) {
+                            clickwriteln!(writer, "{} is an alias for '{}'", hcmd, alias.expanded);
+                        } else {
+                            clickwriteln!(writer, "I don't know anything about {}, sorry", hcmd);
+                        }
                     }
                 }
             }

--- a/src/command_processor.rs
+++ b/src/command_processor.rs
@@ -70,7 +70,7 @@ fn build_parser_expr(line: &str, range: Range<usize>) -> Result<(&str, RightExpr
     }
 }
 
-fn alias_expand_line(env: &Env, line: &str) -> String {
+pub fn alias_expand_line(env: &Env, line: &str) -> String {
     let expa = env.try_expand_alias(line, None);
     let mut alias_stack = vec![expa];
     #[allow(clippy::while_let_loop)] // needed due to borrow restrictions

--- a/src/command_processor.rs
+++ b/src/command_processor.rs
@@ -54,9 +54,9 @@ fn build_parser_expr(line: &str, range: Range<usize>) -> Result<(&str, RightExpr
             b'|' => RightExpr::Pipe(&rest[sepcnt..]),
             b'>' => {
                 if sepcnt == 1 {
-                    RightExpr::Redir(&rest[sepcnt..].trim())
+                    RightExpr::Redir(rest[sepcnt..].trim())
                 } else {
-                    RightExpr::Append(&rest[sepcnt..].trim())
+                    RightExpr::Append(rest[sepcnt..].trim())
                 }
             }
             _ => {
@@ -76,7 +76,7 @@ pub fn alias_expand_line(env: &Env, line: &str) -> String {
     #[allow(clippy::while_let_loop)] // needed due to borrow restrictions
     loop {
         let expa = match alias_stack.last().unwrap().expansion {
-            Some(ref prev) => {
+            Some(prev) => {
                 // previous thing expanded an alias, so try and expand that too
                 env.try_expand_alias(prev.expanded.as_str(), Some(prev.alias.as_str()))
             }

--- a/src/command_processor.rs
+++ b/src/command_processor.rs
@@ -542,6 +542,16 @@ mod tests {
             Vec::new()
         }
 
+        fn try_completed_named(
+            &self,
+            _index: usize,
+            _opt: &str,
+            _prefix: &str,
+            _env: &Env,
+        ) -> Vec<RustlinePair> {
+            Vec::new()
+        }
+
         fn complete_option(&self, _prefix: &str) -> Vec<RustlinePair> {
             Vec::new()
         }

--- a/src/completer.rs
+++ b/src/completer.rs
@@ -45,8 +45,9 @@ impl Hinter for ClickHelper {
 // what we want to really complete with
 fn get_command_completion_strings(
     commands: &Vec<Box<dyn Cmd>>,
-    env: Option<&Rc<Env>>) -> Vec<String> {
-    let mut v = vec!("help".to_string());
+    env: Option<&Rc<Env>>,
+) -> Vec<String> {
+    let mut v = vec!["help".to_string()];
     for cmd in commands.iter() {
         v.push(format!("{}", cmd.get_name()));
     }
@@ -74,10 +75,7 @@ impl ClickHelper {
 
     pub fn set_env(&mut self, env: Option<Rc<Env>>) {
         self.env = env;
-        let command_completions = get_command_completion_strings(
-            &self.commands,
-            self.env.as_ref(),
-        );
+        let command_completions = get_command_completion_strings(&self.commands, self.env.as_ref());
         self.command_completions = command_completions;
     }
 
@@ -97,7 +95,7 @@ impl ClickHelper {
     fn complete_exact_command(&self, line: &str, cmd_len: usize) -> (usize, Vec<Pair>) {
         let mut split = line.split_whitespace();
         let linecmd = split.next().unwrap(); // safe, only ever call this if we know there's a space
-        // gather up any none switch type args
+                                             // gather up any none switch type args
         if let Some(cmd) = self.get_exact_command(linecmd) {
             // first thing is a full command, do complete on it
             // check what we're trying to complete
@@ -116,7 +114,8 @@ impl ClickHelper {
                             None
                         };
                         (count, "", last_opt)
-                    } else if back == "-" { // a lone - completes with another -
+                    } else if back == "-" {
+                        // a lone - completes with another -
                         return (
                             cmd_len,
                             vec![Pair {
@@ -143,7 +142,7 @@ impl ClickHelper {
                             if !pa.starts_with('-') {
                                 // need to count prev_arg as positional as it doesn't start with -
                                 // also make prev_arg None as it's not a -- arg
-                                count+=1;
+                                count += 1;
                                 prev_arg = None;
                             }
                         }
@@ -157,7 +156,7 @@ impl ClickHelper {
             if let Some(ref env) = self.env {
                 match last_opt {
                     Some(opt) => {
-                        let opts = cmd.try_completed_named(opt, prefix, &*env);
+                        let opts = cmd.try_completed_named(pos, opt, prefix, &*env);
                         (cmd_len, opts)
                     }
                     None => {
@@ -166,21 +165,21 @@ impl ClickHelper {
                     }
                 }
             } else {
-                (0, vec!())
+                (0, vec![])
             }
         } else if linecmd == "help" {
             let cmd_part = split.next().unwrap_or("");
             if split.next().is_none() {
-                let mut v = vec!();
+                let mut v = vec![];
                 // only complete on the first arg to help
                 self.get_command_completions(cmd_part, &mut v);
                 self.get_help_completions(cmd_part, &mut v);
                 (5, v) // help plus space is 5 chars
             } else {
-                (0, vec!())
+                (0, vec![])
             }
         } else {
-            (0, vec!())
+            (0, vec![])
         }
     }
 
@@ -212,10 +211,13 @@ impl ClickHelper {
     // }
 
     fn completion_vec(&self) -> Vec<Pair> {
-        self.command_completions.iter().map(|s| Pair {
-            display: s.clone(),
-            replacement: format!("{} ", s),
-        }).collect()
+        self.command_completions
+            .iter()
+            .map(|s| Pair {
+                display: s.clone(),
+                replacement: format!("{} ", s),
+            })
+            .collect()
     }
 }
 
@@ -237,11 +239,15 @@ impl Completer for ClickHelper {
             // complete on it
 
             // if possible, turn an alias into a real command
-            let expanded = self.env.as_ref().map(
-                |e| ::command_processor::alias_expand_line(e, line)
-            );
+            let expanded = self
+                .env
+                .as_ref()
+                .map(|e| ::command_processor::alias_expand_line(e, line));
             Ok(self.complete_exact_command(
-                expanded.as_ref().map(|s| s.as_str()).unwrap_or_else(|| line),
+                expanded
+                    .as_ref()
+                    .map(|s| s.as_str())
+                    .unwrap_or_else(|| line),
                 line.len(),
             ))
         } else {

--- a/src/completer.rs
+++ b/src/completer.rs
@@ -43,17 +43,14 @@ impl Hinter for ClickHelper {
 
 // get a vec with strings that could complete command names. each has a space appended since that's
 // what we want to really complete with
-fn get_command_completion_strings(
-    commands: &Vec<Box<dyn Cmd>>,
-    env: Option<&Rc<Env>>,
-) -> Vec<String> {
+fn get_command_completion_strings(commands: &[Box<dyn Cmd>], env: Option<&Rc<Env>>) -> Vec<String> {
     let mut v = vec!["help".to_string()];
     for cmd in commands.iter() {
-        v.push(format!("{}", cmd.get_name()));
+        v.push(cmd.get_name().to_string());
     }
     if let Some(env) = env.as_ref() {
         for alias in env.click_config.aliases.iter() {
-            v.push(format!("{}", alias.alias));
+            v.push(alias.alias.to_string());
         }
     }
     v.sort_unstable();
@@ -243,13 +240,7 @@ impl Completer for ClickHelper {
                 .env
                 .as_ref()
                 .map(|e| ::command_processor::alias_expand_line(e, line));
-            Ok(self.complete_exact_command(
-                expanded
-                    .as_ref()
-                    .map(|s| s.as_str())
-                    .unwrap_or_else(|| line),
-                line.len(),
-            ))
+            Ok(self.complete_exact_command(expanded.as_deref().unwrap_or(line), line.len()))
         } else {
             // no command with space, so just complete commands
             let mut v = Vec::new();

--- a/src/completer.rs
+++ b/src/completer.rs
@@ -313,7 +313,77 @@ macro_rules! possible_values_completer {
 }
 
 possible_values_completer!(setoptions_values_completer, ::cmd::SET_OPTS);
+
 possible_values_completer!(
     portforwardaction_values_completer,
     ["list", "output", "stop"]
+);
+
+possible_values_completer!(
+    deployment_sort_values_completer,
+    [
+        "Name",
+        "name",
+        "Desired",
+        "desired",
+        "Current",
+        "current",
+        "UpToDate",
+        "uptodate",
+        "Available",
+        "available",
+        "Age",
+        "age",
+        "Labels",
+        "labels"
+    ]
+);
+
+possible_values_completer!(
+    node_sort_values_completer,
+    ["Name", "name", "State", "state", "Age", "age", "Labels", "labels"]
+);
+
+possible_values_completer!(
+    pod_sort_values_completer,
+    [
+        "Name",
+        "name",
+        "Ready",
+        "ready",
+        "Phase",
+        "phase",
+        "Age",
+        "age",
+        "Restarts",
+        "restarts",
+        "Labels",
+        "labels",
+        "Annotations",
+        "annotations",
+        "Node",
+        "node",
+        "Namespace",
+        "namespace"
+    ]
+);
+
+possible_values_completer!(
+    service_sort_values_completer,
+    [
+        "Name",
+        "name",
+        "ClusterIP",
+        "clusterip",
+        "ExternalIP",
+        "externalip",
+        "Age",
+        "age",
+        "Ports",
+        "ports",
+        "Labels",
+        "labels",
+        "Namespace",
+        "namespace"
+    ]
 );

--- a/src/completer.rs
+++ b/src/completer.rs
@@ -41,8 +41,7 @@ impl Hinter for ClickHelper {
     }
 }
 
-// get a vec with strings that could complete command names. each has a space appended since that's
-// what we want to really complete with
+// get a vec with strings that could complete commands or aliases
 fn get_command_completion_strings(commands: &[Box<dyn Cmd>], env: Option<&Rc<Env>>) -> Vec<String> {
     let mut v = vec!["help".to_string()];
     for cmd in commands.iter() {

--- a/src/config/kubefile.rs
+++ b/src/config/kubefile.rs
@@ -213,7 +213,7 @@ impl AuthProvider {
         let v: Value = serde_json::from_str(output).unwrap();
         let mut updated_token = false;
         match self.config.token_key.as_ref() {
-            Some(ref tk) => {
+            Some(tk) => {
                 let token_pntr = AuthProvider::make_pointer(tk.as_str());
                 let extracted_token = v.pointer(token_pntr.as_str()).and_then(|tv| tv.as_str());
                 *token = extracted_token.map(|t| t.to_owned());
@@ -226,7 +226,7 @@ impl AuthProvider {
 
         if updated_token {
             match self.config.expiry_key.as_ref() {
-                Some(ref ek) => {
+                Some(ek) => {
                     let expiry_pntr = AuthProvider::make_pointer(ek.as_str());
                     let extracted_expiry =
                         v.pointer(expiry_pntr.as_str()).and_then(|ev| ev.as_str());

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -116,19 +116,13 @@ where
     let metadata = v.get("metadata").unwrap();
     for (title, item) in fields {
         let val = match item {
-            DescItem::ValStr {
-                path,
-                default,
-            } => val_str(path, v, default),
+            DescItem::ValStr { path, default } => val_str(path, v, default),
             DescItem::Valu64 { path, default } => val_u64(path, v, default).to_string().into(),
             DescItem::KeyValStr {
                 parent,
                 secret_vals,
             } => keyval_str(v, parent, secret_vals),
-            DescItem::MetadataValStr {
-                path,
-                default,
-            } => val_str(path, metadata, default),
+            DescItem::MetadataValStr { path, default } => val_str(path, metadata, default),
             DescItem::ObjectCreated => {
                 let created: DateTime<Utc> = DateTime::from_str(&val_str(
                     "/creationTimestamp",

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -117,17 +117,17 @@ where
     for (title, item) in fields {
         let val = match item {
             DescItem::ValStr {
-                ref path,
-                ref default,
+                path,
+                default,
             } => val_str(path, v, default),
-            DescItem::Valu64 { ref path, default } => val_u64(path, v, default).to_string().into(),
+            DescItem::Valu64 { path, default } => val_u64(path, v, default).to_string().into(),
             DescItem::KeyValStr {
-                ref parent,
+                parent,
                 secret_vals,
             } => keyval_str(v, parent, secret_vals),
             DescItem::MetadataValStr {
-                ref path,
-                ref default,
+                path,
+                default,
             } => val_str(path, metadata, default),
             DescItem::ObjectCreated => {
                 let created: DateTime<Utc> = DateTime::from_str(&val_str(

--- a/src/env.rs
+++ b/src/env.rs
@@ -214,9 +214,8 @@ impl Env {
 
     // return the alias struct for the specified alias
     pub fn get_alias(&self, alias: &str) -> Option<&Alias> {
-        self.alias_position(alias).and_then(
-            |p| self.click_config.aliases.get(p)
-        )
+        self.alias_position(alias)
+            .and_then(|p| self.click_config.aliases.get(p))
     }
 
     pub fn add_alias(&mut self, alias: Alias) {

--- a/src/env.rs
+++ b/src/env.rs
@@ -212,6 +212,13 @@ impl Env {
             .position(|a| a.alias == *alias)
     }
 
+    // return the alias struct for the specified alias
+    pub fn get_alias(&self, alias: &str) -> Option<&Alias> {
+        self.alias_position(alias).and_then(
+            |p| self.click_config.aliases.get(p)
+        )
+    }
+
     pub fn add_alias(&mut self, alias: Alias) {
         self.remove_alias(&alias.alias);
         self.click_config.aliases.push(alias);

--- a/src/kube.rs
+++ b/src/kube.rs
@@ -508,7 +508,7 @@ impl Kluster {
                 ip = Some(host.to_owned());
             }
         };
-        if let (Some(ref host), Some(ref _ip_addr)) = (dns_host.as_ref(), ip.as_ref()) {
+        if let (Some(host), Some(_ip_addr)) = (dns_host.as_ref(), ip.as_ref()) {
             // The cert has a matching IP and a host name, use that
             endpoint.set_host(Some(host.as_str())).unwrap();
         }
@@ -761,7 +761,7 @@ impl Kluster {
         let client = self.client.borrow();
         let req = client.delete(url);
         let req = match body {
-            Some(ref b) => {
+            Some(b) => {
                 let hyper_body = Body::BufBody(b.as_bytes(), b.len());
                 req.body(hyper_body)
             }

--- a/src/table.rs
+++ b/src/table.rs
@@ -98,14 +98,14 @@ impl<'a> CellSpec<'a> {
     }
 
     pub fn to_cell(&self, index: usize) -> Cell {
-        let mut cell = match self.txt {
+        let mut cell = match &self.txt {
             CellSpecTxt::Index => {
                 let mut c = Cell::new(format!("{}", index).as_str());
                 c.align(format::Alignment::RIGHT);
                 c
             }
-            CellSpecTxt::Str(ref s) => Cell::new(s),
-            CellSpecTxt::String(ref s) => Cell::new(s.as_str()),
+            CellSpecTxt::Str(s) => Cell::new(s),
+            CellSpecTxt::String(s) => Cell::new(s.as_str()),
         };
 
         if let Some(a) = self.align {
@@ -122,7 +122,7 @@ impl<'a> CellSpec<'a> {
     pub fn matches(&self, regex: &Regex) -> bool {
         match self.txt {
             CellSpecTxt::Index => false,
-            CellSpecTxt::Str(ref s) => regex.is_match(s),
+            CellSpecTxt::Str(s) => regex.is_match(s),
             CellSpecTxt::String(ref s) => regex.is_match(s),
         }
     }
@@ -182,7 +182,7 @@ fn term_print_table<T: Write>(table: &Table, writer: &mut T) -> bool {
 
 pub fn print_filled_table(table: &mut Table, writer: &mut ClickWriter) {
     table.set_format(*TBLFMT);
-    if !term_print_table(&table, writer) {
+    if !term_print_table(table, writer) {
         table.print(writer).unwrap_or(0);
     }
 }
@@ -198,7 +198,7 @@ pub fn print_table<'a, T>(
         table.add_row(Row::new(row_vec));
     }
     table.set_format(*TBLFMT);
-    if !term_print_table(&table, writer) {
+    if !term_print_table(table, writer) {
         table.print(writer).unwrap_or(0);
     }
 }


### PR DESCRIPTION
This allows specifying completions for named options. It also adds completers for the various --sort args, and for the --container arg to exec 