### PR TITLE
Add support for argo rollouts

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -21,8 +21,8 @@ use crate::error::KubeError;
 use crate::kobj::{KObj, ObjType, VecWrap};
 use crate::kube::{
     ConfigMapList, ContainerState, Deployment, DeploymentList, Event, EventList, JobList, Metadata,
-    NamespaceList, Node, NodeCondition, NodeList, Pod, PodList, ReplicaSetList, Rollout, RolloutList,
-    SecretList, Service, ServiceList, StatefulSetList,
+    NamespaceList, Node, NodeCondition, NodeList, Pod, PodList, ReplicaSetList, Rollout,
+    RolloutList, SecretList, Service, ServiceList, StatefulSetList,
 };
 use crate::output::ClickWriter;
 use crate::table::{opt_sort, CellSpec};
@@ -1015,8 +1015,13 @@ fn print_rollouts(
 
     crate::table::print_table(&mut table, &filtered, writer);
 
-    let final_rollouts = filtered.into_iter().map(|rollout_spec| rollout_spec.0).collect();
-    RolloutList { items: final_rollouts }
+    let final_rollouts = filtered
+        .into_iter()
+        .map(|rollout_spec| rollout_spec.0)
+        .collect();
+    RolloutList {
+        items: final_rollouts,
+    }
 }
 
 // service utility functions

--- a/src/command_processor.rs
+++ b/src/command_processor.rs
@@ -187,6 +187,7 @@ impl CommandProcessor {
             Box::new(crate::cmd::Jobs::new()),
             Box::new(crate::cmd::Alias::new()),
             Box::new(crate::cmd::Unalias::new()),
+            Box::new(crate::cmd::Rollouts::new()),
         ];
         commands
     }

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -706,3 +706,83 @@ pub fn describe_format_deployment(v: Value) -> String {
     ];
     describe_object(&v, fields.into_iter())
 }
+
+/// Utility function to describe a rollout
+pub fn describe_format_rollout(v: Value) -> String {
+    let fields = vec![
+        (
+            "Name:\t\t",
+            DescItem::MetadataValStr {
+                path: "/name",
+                default: "<No Name>",
+            },
+        ),
+        (
+            "Namespace:\t",
+            DescItem::MetadataValStr {
+                path: "/namespace",
+                default: "<No Name>",
+            },
+        ),
+        ("Created at:\t", DescItem::ObjectCreated),
+        (
+            "Generation:\t",
+            DescItem::Valu64 {
+                path: "/metadata/generation",
+                default: 0,
+            },
+        ),
+        (
+            "Labels:\t",
+            DescItem::KeyValStr {
+                parent: "/metadata/labels",
+                secret_vals: false,
+            },
+        ),
+        (
+            "Desired Replicas:\t",
+            DescItem::Valu64 {
+                path: "/spec/replicas",
+                default: 0,
+            },
+        ),
+        (
+            "Current Replicas:\t",
+            DescItem::Valu64 {
+                path: "/status/replicas",
+                default: 0,
+            },
+        ),
+        (
+            "Up To Date Replicas:\t",
+            DescItem::Valu64 {
+                path: "/status/updatedReplicas",
+                default: 0,
+            },
+        ),
+        (
+            "Available Replicas:\t",
+            DescItem::Valu64 {
+                path: "/status/availableReplicas",
+                default: 0,
+            },
+        ),
+        (
+            "\nContainers:\n",
+            DescItem::CustomFunc {
+                path: Some("/spec/template/spec/containers"),
+                func: &get_container_str,
+                default: "<No Containers>",
+            },
+        ),
+        (
+            "Messages:\n",
+            DescItem::CustomFunc {
+                path: Some("/status/conditions"),
+                func: &get_message_str,
+                default: "<No Messages>",
+            },
+        ),
+    ];
+    describe_object(&v, fields.into_iter())
+}

--- a/src/kobj.rs
+++ b/src/kobj.rs
@@ -19,6 +19,7 @@ pub enum ObjType {
     Deployment,
     Service,
     ReplicaSet,
+    Rollout,
     StatefulSet,
     ConfigMap,
     Secret,
@@ -71,6 +72,16 @@ impl From<crate::kube::DeploymentList> for Vec<KObj> {
             .items
             .iter()
             .map(|dep| KObj::from_metadata(&dep.metadata, ObjType::Deployment))
+            .collect()
+    }
+}
+
+impl From<crate::kube::RolloutList> for Vec<KObj> {
+    fn from(rolloutlist: crate::kube::RolloutList) -> Self {
+        rolloutlist
+            .items
+            .iter()
+            .map(|dep| KObj::from_metadata(&dep.metadata, ObjType::Rollout))
             .collect()
     }
 }
@@ -156,6 +167,7 @@ impl KObj {
             ObjType::Deployment => "Deployment",
             ObjType::Service => "Service",
             ObjType::ReplicaSet => "ReplicaSet",
+            ObjType::Rollout => "Rollout",
             ObjType::StatefulSet => "StatefulSet",
             ObjType::ConfigMap => "ConfigMap",
             ObjType::Secret => "Secret",
@@ -170,6 +182,7 @@ impl KObj {
             ObjType::Deployment => Purple.bold().paint(self.name.as_str()),
             ObjType::Service => Cyan.bold().paint(self.name.as_str()),
             ObjType::ReplicaSet => Green.bold().paint(self.name.as_str()),
+            ObjType::Rollout => Purple.bold().paint(self.name.as_str()),
             ObjType::StatefulSet => Green.bold().paint(self.name.as_str()),
             ObjType::ConfigMap => Purple.bold().paint(self.name.as_str()),
             ObjType::Secret => Red.bold().paint(self.name.as_str()),
@@ -197,6 +210,10 @@ impl KObj {
             ObjType::Service => format!("/api/v1/namespaces/{}/services/{}", namespace, self.name),
             ObjType::ReplicaSet => format!(
                 "/apis/extensions/v1beta1/namespaces/{}/replicasets/{}",
+                namespace, self.name
+            ),
+            ObjType::Rollout => format!(
+                "/apis/argoproj.io/v1alpha1/namespaces/{}/rollouts/{}",
                 namespace, self.name
             ),
             ObjType::StatefulSet => format!(
@@ -236,6 +253,9 @@ impl KObj {
                         }
                         ObjType::Deployment => {
                             clickwriteln!(writer, "{}", describe::describe_format_deployment(val))
+                        }
+                        ObjType::Rollout => {
+                            clickwriteln!(writer, "{}", describe::describe_format_rollout(val))
                         }
                         ObjType::Secret => {
                             clickwriteln!(writer, "{}", describe::describe_format_secret(val))

--- a/src/kube.rs
+++ b/src/kube.rs
@@ -291,6 +291,35 @@ pub struct DeploymentList {
     pub items: Vec<Deployment>,
 }
 
+// Rollouts
+#[derive(Debug, Deserialize)]
+pub struct RolloutSpec {
+    #[serde(default = "replicas_one")]
+    pub replicas: u32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RolloutStatus {
+    #[serde(default = "replicas_none")]
+    pub replicas: u32,
+    #[serde(default = "replicas_none", rename = "availableReplicas")]
+    pub available: u32,
+    #[serde(default = "replicas_none", rename = "updatedReplicas")]
+    pub updated: u32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Rollout {
+    pub metadata: Metadata,
+    pub spec: RolloutSpec,
+    pub status: RolloutStatus,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RolloutList {
+    pub items: Vec<Rollout>,
+}
+
 // Services
 fn tcp_str() -> String {
     "TCP".to_owned()


### PR DESCRIPTION
This adds support for argo rollouts.

Here's proof it works:
[aws-us-west-2] [development] [none] > rollouts
 ####  Name              Desired  Current  Up To Date  Available  Age
-------------------------------------------------------------------------
    0  service             2        2         2           2      4h 58m
-------------------------------------------------------------------------
[aws-us-west-2] [development] [none] > 0
[aws-us-west-2] [development] [service] > describe
Name:		service
Namespace:	development
Created at:	2021-09-28 13:55:10 UTC (2021-09-28 06:55:10 -07:00)
Generation:	2
Labels:		app=service
Desired Replicas:	2
Current Replicas:	2
Up To Date Replicas:	2
Available Replicas:	2

Containers:
  Name: service
    Image:	myimage

Messages:
  Message: RolloutCompleted
  Message: ReplicaSet "service-84fb8ff6" has successfully progressed.
  Message: Rollout has minimum availability