### PR TITLE
Make requests return ClickErrors, and env return Result not Option

### DIFF
--- a/src/completer.rs
+++ b/src/completer.rs
@@ -271,9 +271,8 @@ pub fn context_complete(prefix: &str, env: &Env) -> Vec<Pair> {
 
 pub fn namespace_completer(prefix: &str, env: &Env) -> Vec<Pair> {
     let (request, _response_body) = api::Namespace::list_namespace(Default::default()).unwrap();
-    let ns_opt: Option<List<api::Namespace>> = env.run_on_context(|c| c.execute_list(request));
-    match ns_opt {
-        Some(nslist) => nslist
+    match env.run_on_context::<_, List<api::Namespace>>(|c| c.execute_list(request)) {
+        Ok(nslist) => nslist
             .items
             .into_iter()
             .filter_map(|ns| {
@@ -290,7 +289,7 @@ pub fn namespace_completer(prefix: &str, env: &Env) -> Vec<Pair> {
                 })
             })
             .collect(),
-        None => vec![],
+        Err(_) => vec![],
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -394,22 +394,13 @@ impl Env {
         }
     }
 
-    pub fn run_on_context<F, R>(&self, f: F) -> Option<R>
+    pub fn run_on_context<F, R>(&self, f: F) -> Result<R, ClickError>
     where
-        F: FnOnce(&crate::k8s::Context) -> Result<R, Box<dyn std::error::Error>>,
+        F: FnOnce(&crate::k8s::Context) -> Result<R, ClickError>,
     {
         match self.context {
-            Some(ref c) => match f(c) {
-                Ok(r) => Some(r),
-                Err(e) => {
-                    println!("{}", e);
-                    None
-                }
-            },
-            None => {
-                println!("Need to have an active context");
-                None
-            }
+            Some(ref c) => f(c),
+            None => Err(ClickError::CommandError("No active context".to_string())),
         }
     }
 


### PR DESCRIPTION
This allows better error handling at higher levels. For this particular PR the main noticable
difference is that the `logs` command will print a more reasonable error if the api-server returns a
failure.