### PR TITLE
Make CellSpecTxt hold different types

### DIFF
--- a/src/command/command_def.rs
+++ b/src/command/command_def.rs
@@ -14,7 +14,6 @@
 
 /// This module contains shared code that's useful for defining commands
 use clap::{App, AppSettings, Arg, ArgMatches};
-use k8s_openapi::{apimachinery::pkg::apis::meta::v1::ObjectMeta, Metadata};
 use rustyline::completion::Pair as RustlinePair;
 
 use crate::env::Env;
@@ -22,7 +21,6 @@ use crate::error::ClickError;
 use crate::output::ClickWriter;
 
 use std::cell::RefCell;
-use std::cmp::Ordering;
 use std::io::Write;
 
 // command definition
@@ -409,28 +407,8 @@ pub fn add_extra_cols<'a>(
     }
 }
 
-// TODO: this should be removed all together in favor of keeping a cellspec in a sortable form until
-// just before display
-pub enum SortFunc<T> {
-    Pre(PreExtractSort<T>),
-    Post(&'static str), // sort based on column index given
-}
-
-/// A function that can sort based on a column, pre extraction
-pub struct PreExtractSort<T> {
-    pub cmp: fn(a: &T, b: &T) -> Ordering,
-}
-
-pub fn age_cmp<T: Metadata<Ty = ObjectMeta>>(a: &T, b: &T) -> Ordering {
-    let ato = a.metadata().creation_timestamp.as_ref();
-    let bto = b.metadata().creation_timestamp.as_ref();
-    match (ato, bto) {
-        (None, None) => Ordering::Equal,
-        (Some(_), None) => Ordering::Greater,
-        (None, Some(_)) => Ordering::Less,
-        (Some(at), Some(bt)) => at.0.cmp(&bt.0),
-    }
-}
+// sort based on column index given
+pub struct SortCol(pub &'static str);
 
 /// get a clap arg for sorting. this takes one or two lists of possible values to allow for passing
 /// normal and extra cols

--- a/src/command/events.rs
+++ b/src/command/events.rs
@@ -19,6 +19,7 @@ use k8s_openapi::{api::core::v1 as api, http::Request, List};
 use prettytable::{Cell, Row, Table};
 use rustyline::completion::Pair as RustlinePair;
 
+use crate::command::format_duration;
 use crate::{
     command::command_def::{exec_match, start_clap, Cmd},
     command::time_since,
@@ -115,11 +116,11 @@ fn print_events(
                 ));
             }
             let timestr = match event.last_timestamp.as_ref() {
-                Some(ts) => time_since(ts.0),
+                Some(ts) => format_duration(time_since(ts.0)),
                 None => event
                     .event_time
                     .as_ref()
-                    .map(|t| time_since(t.0))
+                    .map(|t| format_duration(time_since(t.0)))
                     .unwrap_or_else(|| "unknown".to_string()),
             };
             row.push(Cell::new(&timestr));

--- a/src/command/jobs.rs
+++ b/src/command/jobs.rs
@@ -75,7 +75,6 @@ fn job_completions(job: &batch_api::Job) -> Option<CellSpec<'_>> {
     Some(format!("{}/{}", succeeded, completions).into())
 }
 
-// TODO: Switch to a CellSpec for duration when removing the SortFunc stuff
 fn job_duration(job: &batch_api::Job) -> Option<CellSpec<'_>> {
     let stat = job.status.as_ref();
     match stat.and_then(|s| s.start_time.as_ref()) {

--- a/src/command/jobs.rs
+++ b/src/command/jobs.rs
@@ -18,7 +18,7 @@ use k8s_openapi::api::batch::v1 as batch_api;
 
 use crate::{
     command::command_def::{exec_match, show_arg, sort_arg, start_clap, Cmd},
-    command::{format_duration, keyval_string, run_list_command, time_since, Extractor},
+    command::{keyval_string, run_list_command, time_since, Extractor},
     completer,
     env::Env,
     kobj::{KObj, ObjType},
@@ -95,7 +95,7 @@ fn job_duration(job: &batch_api::Job) -> Option<CellSpec<'_>> {
             match end {
                 Some(end) => {
                     let diff = end.0.signed_duration_since(start.0);
-                    Some(format_duration(diff).into())
+                    Some(diff.into())
                 }
                 None => Some(time_since(start.0).into()),
             }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -112,35 +112,26 @@ where
         None => vec![],
     };
 
-    let sort = matches
-        .value_of("sort")
-        .map(|s| match s.to_lowercase().as_str() {
-            "age" => {
-                let sf = command_def::PreExtractSort {
-                    cmp: command_def::age_cmp,
-                };
-                command_def::SortFunc::Pre(sf)
-            }
-            other => {
-                if let Some(col) = mapped_val(other, col_map) {
-                    command_def::SortFunc::Post(col)
-                } else if let Some(ecm) = extra_col_map {
-                    let mut func = None;
-                    for (flag, col) in ecm.iter() {
-                        if flag.eq(&other) {
-                            flags.push(flag);
-                            func = Some(command_def::SortFunc::Post(col));
-                        }
-                    }
-                    match func {
-                        Some(f) => f,
-                        None => panic!("Shouldn't be allowed to ask to sort by: {}", other),
-                    }
-                } else {
-                    panic!("Shouldn't be allowed to ask to sort by: {}", other);
+    let sort = matches.value_of("sort").map(|s| {
+        let colname = s.to_lowercase();
+        if let Some(col) = mapped_val(&colname, col_map) {
+            command_def::SortCol(col)
+        } else if let Some(ecm) = extra_col_map {
+            let mut func = None;
+            for (flag, col) in ecm.iter() {
+                if flag.eq(&colname) {
+                    flags.push(flag);
+                    func = Some(command_def::SortCol(col));
                 }
             }
-        });
+            match func {
+                Some(f) => f,
+                None => panic!("Shouldn't be allowed to ask to sort by: {}", colname),
+            }
+        } else {
+            panic!("Shouldn't be allowed to ask to sort by: {}", colname);
+        }
+    });
 
     if let Some(ecm) = extra_col_map {
         // if we're not in a namespace, we want to add a namespace col if it's in extra_col_map
@@ -208,10 +199,10 @@ pub fn handle_list_result<'a, T, F>(
     env: &mut Env,
     writer: &mut ClickWriter,
     cols: Vec<&str>,
-    mut list: List<T>,
+    list: List<T>,
     extractors: Option<&HashMap<String, Extractor<T>>>,
     regex: Option<Regex>,
-    sort: Option<command_def::SortFunc<T>>,
+    sort: Option<command_def::SortCol>,
     reverse: bool,
     get_kobj: F,
 ) -> Result<(), ClickError>
@@ -219,10 +210,6 @@ where
     T: 'a + ListableResource + Metadata<Ty = ObjectMeta>,
     F: Fn(&T) -> KObj,
 {
-    if let Some(command_def::SortFunc::Pre(func)) = sort.as_ref() {
-        list.items.sort_by(|a, b| (func.cmp)(a, b));
-    }
-
     let mut specs = build_specs(&cols, &list, extractors, true, regex, get_kobj);
 
     let mut titles: Vec<Cell> = vec![Cell::new("####")];
@@ -231,7 +218,7 @@ where
         titles.push(Cell::new(col));
     }
 
-    if let Some(command_def::SortFunc::Post(colname)) = sort {
+    if let Some(command_def::SortCol(colname)) = sort {
         let index = cols.iter().position(|&c| c == colname);
         match index {
             Some(index) => {
@@ -331,11 +318,9 @@ pub fn extract_name<T: Metadata<Ty = ObjectMeta>>(obj: &T) -> Option<Cow<'_, str
 }
 
 /// An extractor for the Age field. Extracts the age out of the object metadata
-pub fn extract_age<T: Metadata<Ty = ObjectMeta>>(obj: &T) -> Option<Cow<'_, str>> {
+pub fn extract_age<T: Metadata<Ty = ObjectMeta>>(obj: &T) -> Option<CellSpec<'_>> {
     let meta = obj.metadata();
-    meta.creation_timestamp
-        .as_ref()
-        .map(|ts| format_duration(time_since(ts.0)).into())
+    meta.creation_timestamp.as_ref().map(|ts| ts.0.into())
 }
 
 /// An extractor for the Namespace field. Extracts the namespace out of the object metadata

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -335,7 +335,7 @@ pub fn extract_age<T: Metadata<Ty = ObjectMeta>>(obj: &T) -> Option<Cow<'_, str>
     let meta = obj.metadata();
     meta.creation_timestamp
         .as_ref()
-        .map(|ts| time_since(ts.0).into())
+        .map(|ts| format_duration(time_since(ts.0)).into())
 }
 
 /// An extractor for the Namespace field. Extracts the namespace out of the object metadata
@@ -390,10 +390,9 @@ pub fn format_duration(duration: Duration) -> String {
     }
 }
 
-pub fn time_since(date: DateTime<Utc>) -> String {
+pub fn time_since(date: DateTime<Utc>) -> Duration {
     let now = Utc::now();
-    let diff = now.signed_duration_since(date);
-    format_duration(diff)
+    now.signed_duration_since(date)
 }
 
 /// Build a multi-line string of the specified keyvals

--- a/src/command/volumes.rs
+++ b/src/command/volumes.rs
@@ -14,7 +14,7 @@
 
 use ansi_term::Colour::Yellow;
 use clap::{App, Arg};
-use k8s_openapi::api::core::v1 as api;
+use k8s_openapi::{api::core::v1 as api, apimachinery::pkg::api::resource::Quantity};
 
 use crate::{
     command::command_def::{exec_match, show_arg, sort_arg, start_clap, Cmd},
@@ -73,13 +73,15 @@ fn pv_to_kobj(volume: &api::PersistentVolume) -> KObj {
     }
 }
 
-// TODO: Switch to a capacity col type
 fn volume_capacity(volume: &api::PersistentVolume) -> Option<CellSpec<'_>> {
     volume.spec.as_ref().and_then(|spec| {
         spec.capacity
             .get("storage")
             .as_ref()
-            .map(|q| q.0.clone().into())
+            .map(|q| {
+                let quant = Quantity(q.0.clone());
+                quant.into()
+            })
     })
 }
 

--- a/src/command/volumes.rs
+++ b/src/command/volumes.rs
@@ -75,13 +75,10 @@ fn pv_to_kobj(volume: &api::PersistentVolume) -> KObj {
 
 fn volume_capacity(volume: &api::PersistentVolume) -> Option<CellSpec<'_>> {
     volume.spec.as_ref().and_then(|spec| {
-        spec.capacity
-            .get("storage")
-            .as_ref()
-            .map(|q| {
-                let quant = Quantity(q.0.clone());
-                quant.into()
-            })
+        spec.capacity.get("storage").as_ref().map(|q| {
+            let quant = Quantity(q.0.clone());
+            quant.into()
+        })
     })
 }
 


### PR DESCRIPTION
This allows us to keep things in a sortable form until just before printing, so there's no need for odd Pre/Post sort stuff as before.