### PR TITLE
need arg names to line up

### DIFF
--- a/src/command/configmaps.rs
+++ b/src/command/configmaps.rs
@@ -67,7 +67,7 @@ list_command!(
     super::EXTRA_COL_FLAGS,
     |clap: ClapCommand<'static>| clap
         .arg(
-            Arg::new("show_label")
+            Arg::new("labels")
                 .short('L')
                 .long("labels")
                 .help("Show configmap labels (deprecated, use --show labels)")

--- a/src/command/deployments.rs
+++ b/src/command/deployments.rs
@@ -142,7 +142,7 @@ list_command!(
     super::EXTRA_COL_FLAGS,
     |clap: ClapCommand<'static>| clap
         .arg(
-            Arg::new("show_label")
+            Arg::new("labels")
                 .short('L')
                 .long("labels")
                 .help("Show deployments labels (deprecated, use --show labels)")

--- a/src/command/jobs.rs
+++ b/src/command/jobs.rs
@@ -145,7 +145,7 @@ list_command!(
     super::EXTRA_COL_FLAGS,
     |clap: ClapCommand<'static>| clap
         .arg(
-            Arg::new("show_label")
+            Arg::new("labels")
                 .short('L')
                 .long("labels")
                 .help("Show job labels (deprecated, use --show labels)")

--- a/src/command/replicasets.rs
+++ b/src/command/replicasets.rs
@@ -138,7 +138,7 @@ list_command!(
     super::EXTRA_COL_FLAGS,
     |clap: ClapCommand<'static>| clap
         .arg(
-            Arg::new("show_label")
+            Arg::new("labels")
                 .short('L')
                 .long("labels")
                 .help("Show replicasets labels (deprecated, use --show labels)")

--- a/src/command/rollouts.rs
+++ b/src/command/rollouts.rs
@@ -96,7 +96,7 @@ list_command!(
     super::EXTRA_COL_FLAGS,
     |clap: ClapCommand<'static>| clap
         .arg(
-            Arg::new("show_label")
+            Arg::new("labels")
                 .short('L')
                 .long("labels")
                 .help("Show statefulsets labels (deprecated, use --show labels)")

--- a/src/command/secrets.rs
+++ b/src/command/secrets.rs
@@ -77,7 +77,7 @@ list_command!(
     super::EXTRA_COL_FLAGS,
     |clap: ClapCommand<'static>| clap
         .arg(
-            Arg::new("show_label")
+            Arg::new("labels")
                 .short('L')
                 .long("labels")
                 .help("Show secrets labels (deprecated, use --show labels)")

--- a/src/command/statefulsets.rs
+++ b/src/command/statefulsets.rs
@@ -127,7 +127,7 @@ list_command!(
     super::EXTRA_COL_FLAGS,
     |clap: ClapCommand<'static>| clap
         .arg(
-            Arg::new("show_label")
+            Arg::new("labels")
                 .short('L')
                 .long("labels")
                 .help("Show statefulsets labels (deprecated, use --show labels)")


### PR DESCRIPTION
Now that it's all unified, everything needs to use the `labels` arg name