### PR TITLE
initial migration to abstracted colors using crossterm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "atomicwrites"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,14 +154,15 @@ dependencies = [
 name = "click"
 version = "0.6.0"
 dependencies = [
- "ansi_term",
  "atomicwrites",
  "base64",
  "bytes",
  "chrono",
  "clap",
  "comfy-table",
+ "crossterm",
  "ctrlc",
+ "derivative",
  "dirs",
  "duct",
  "duct_sh",
@@ -321,6 +313,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ travis-ci = { repository = "databricks/click" }
 argorollouts = [] # enable the `rollouts` command to view argo rollouts
 
 [dependencies]
-ansi_term = "^0.12"
 atomicwrites = "^0.3"
 base64 = "^0.13"
 bytes = "1.0.1"
 chrono = { version = "^0.4", features = ["serde"] }
 clap = { version = "^3.1", features = ["cargo", "color"] }
 comfy-table = "^5.0"
+crossterm = "^0.23"
 ctrlc = "^3.1"
 dirs = "^4.0"
 duct = "^0.13"
@@ -50,3 +50,4 @@ tempdir = "^0.3"
 tokio = { version = "1", features = ["full"] }
 url = "^2.2"
 yasna = "^0.5"
+derivative = "2.2.0"

--- a/src/command/alias.rs
+++ b/src/command/alias.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use rustyline::completion::Pair as RustlinePair;
 

--- a/src/command/click.rs
+++ b/src/command/click.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use chrono::offset::Utc;
 use clap::{Arg, Command as ClapCommand};
 use comfy_table::Table;
@@ -57,7 +56,7 @@ fn print_contexts(env: &Env, writer: &mut ClickWriter) {
             };
             row.push(CellSpec::with_colors(
                 (*context).clone().into(),
-                Some(comfy_table::Color::Red),
+                Some(env.styles.context_table_color()),
                 None,
             ));
             row.push(cluster.into());

--- a/src/command/click.rs
+++ b/src/command/click.rs
@@ -56,14 +56,14 @@ fn print_contexts(env: &Env, writer: &mut ClickWriter) {
             };
             row.push(CellSpec::with_colors(
                 (*context).clone().into(),
-                Some(env.styles.context_table_color()),
+                Some(env.styles.context_table_color().into()),
                 None,
             ));
             row.push(cluster.into());
             row
         })
         .collect();
-    crate::table::print_table(vec!["Context", "Api Server Address"], ctxs, writer);
+    crate::table::print_table(vec!["Context", "Api Server Address"], ctxs, env, writer);
 }
 
 command!(

--- a/src/command/command_def.rs
+++ b/src/command/command_def.rs
@@ -219,9 +219,10 @@ macro_rules! command {
 
         impl $cmd_name {
             pub fn new() -> $cmd_name {
+                use crossterm::style::Stylize;
                 lazy_static! {
                     static ref ALIASES_STR: String =
-                        format!("{}:\n    {:?}", Yellow.paint("ALIASES"), $aliases);
+                        format!("{}:\n    {:?}", "ALIASES".yellow(), $aliases);
                 }
                 let clap = start_clap($name, $about, &ALIASES_STR, $trailing_var_arg);
                 let extra = $extra_args(clap);

--- a/src/command/configmaps.rs
+++ b/src/command/configmaps.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::api::core::v1 as api;
 

--- a/src/command/copy.rs
+++ b/src/command/copy.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use rustyline::completion::Pair as RustlinePair;
 

--- a/src/command/crds.rs
+++ b/src/command/crds.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 
 use rustyline::completion::Pair as RustlinePair;

--- a/src/command/crds.rs
+++ b/src/command/crds.rs
@@ -105,6 +105,7 @@ command!(
                 match env.run_on_context::<_, GetTableResponse>(|c| c.read(request))? {
                     GetTableResponse::Ok(resp) => {
                         let kobjs = resp.print_to(
+                            env,
                             env.namespace.is_none(),
                             &desc.name,
                             &desc.group_version,

--- a/src/command/daemonsets.rs
+++ b/src/command/daemonsets.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::api::apps::v1 as apps_api;
 

--- a/src/command/delete.rs
+++ b/src/command/delete.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::{
     api::apps::v1 as api_apps, api::batch::v1 as api_batch, api::core::v1 as api,

--- a/src/command/deployments.rs
+++ b/src/command/deployments.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::api::apps::v1 as apps_api;
 

--- a/src/command/describe.rs
+++ b/src/command/describe.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use rustyline::completion::Pair as RustlinePair;
 

--- a/src/command/events.rs
+++ b/src/command/events.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use chrono::{offset::Utc, DateTime};
 use clap::Command as ClapCommand;
 use comfy_table::{Cell, Table};

--- a/src/command/exec.rs
+++ b/src/command/exec.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use rustyline::completion::Pair as RustlinePair;
 

--- a/src/command/jobs.rs
+++ b/src/command/jobs.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::api::batch::v1 as batch_api;
 

--- a/src/command/logs.rs
+++ b/src/command/logs.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use chrono::offset::{Local, Utc};
 use chrono::DateTime;
 use clap::{Arg, Command as ClapCommand};

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -247,7 +247,7 @@ where
         specs.into_iter().unzip()
     };
 
-    crate::table::print_table(titles, rows, writer);
+    crate::table::print_table(titles, rows, env, writer);
     env.set_last_objs(kobjs);
     Ok(())
 }

--- a/src/command/namespaces.rs
+++ b/src/command/namespaces.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::api::core::v1 as api;
 use rustyline::completion::Pair as RustlinePair;

--- a/src/command/nodes.rs
+++ b/src/command/nodes.rs
@@ -150,14 +150,15 @@ fn node_state<'a>(node: &'a api::Node) -> Option<CellSpec<'a>> {
             .as_ref()
             .and_then(|conditions| conditions.iter().find(|c| c.type_ == "Ready"))
     });
+    use crate::table::ColorType;
     let (state, fg) = if let Some(cond) = readycond {
         if cond.status == "True" {
-            ("Ready", comfy_table::Color::DarkGreen)
+            ("Ready", ColorType::Success)
         } else {
-            ("Not Ready", comfy_table::Color::DarkRed)
+            ("Not Ready", ColorType::Danger)
         }
     } else {
-        ("Unknown", comfy_table::Color::DarkYellow)
+        ("Unknown", ColorType::Warn)
     };
 
     let state: Cow<'a, str> = match node.spec.as_ref().and_then(|spec| spec.unschedulable) {
@@ -170,7 +171,7 @@ fn node_state<'a>(node: &'a api::Node) -> Option<CellSpec<'a>> {
         }
         None => state.into(),
     };
-    Some(CellSpec::with_colors(state, Some(fg), None))
+    Some(CellSpec::with_colors(state, Some(fg.into()), None))
 }
 
 fn node_version(node: &api::Node) -> Option<CellSpec<'_>> {

--- a/src/command/nodes.rs
+++ b/src/command/nodes.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::api::core::v1 as api;
 

--- a/src/command/pods.rs
+++ b/src/command/pods.rs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::{
-    Colour::{Green, Red, Yellow},
-    Style,
-};
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::api::core::v1 as api;
 use k8s_openapi::ListOptional;
@@ -28,6 +24,7 @@ use crate::{
     error::ClickError,
     kobj::{KObj, ObjType},
     output::ClickWriter,
+    styles::Styles,
     table::CellSpec,
 };
 
@@ -380,14 +377,14 @@ fn print_containers(
         {
             Some(container_statuses) => {
                 for cont in container_statuses.iter() {
-                    clickwrite!(writer, "Name:\t{}\n", Style::new().bold().paint(&cont.name));
+                    clickwrite!(writer, "Name:\t{}\n", env.styles.bold(cont.name.as_str()));
                     clickwrite!(
                         writer,
                         "  ID:\t\t{}\n",
                         cont.container_id.as_deref().unwrap_or("<none>")
                     );
                     clickwrite!(writer, "  Image:\t{}\n", cont.image_id);
-                    print_state_string(&cont.state, writer);
+                    print_state_string(&cont.state, &env.styles, writer);
                     clickwrite!(writer, "  Ready:\t{}\n", cont.ready);
                     clickwrite!(writer, "  Restarts:\t{}\n", cont.restart_count);
 
@@ -465,12 +462,16 @@ fn print_containers(
     }
 }
 
-fn print_state_string(state: &Option<api::ContainerState>, writer: &mut ClickWriter) {
+fn print_state_string(
+    state: &Option<api::ContainerState>,
+    styles: &Styles,
+    writer: &mut ClickWriter,
+) {
     clickwrite!(writer, "  State:\t");
     match state {
         Some(state) => {
             if let Some(running) = state.running.as_ref() {
-                clickwrite!(writer, "{}\n", Green.paint("Running"));
+                clickwrite!(writer, "{}\n", styles.success("Running"));
                 match &running.started_at {
                     Some(start) => clickwrite!(writer, "\t\t  started at: {}\n", start.0),
                     None => clickwrite!(writer, "\t\t  since unknown\n"),
@@ -483,7 +484,7 @@ fn print_state_string(state: &Option<api::ContainerState>, writer: &mut ClickWri
                     .as_ref()
                     .map(|fa| fa.0.to_string())
                     .unwrap_or_else(|| "<unknown>".to_string());
-                clickwrite!(writer, "{}\n", Red.paint("Terminated"));
+                clickwrite!(writer, "{}\n", styles.danger("Terminated"));
                 clickwrite!(writer, "\t\t  at: {}\n", tsr);
                 clickwrite!(writer, "\t\t  code: {}\n", terminated.exit_code);
                 clickwrite!(writer, "\t\t  message: {}\n", message);
@@ -491,14 +492,14 @@ fn print_state_string(state: &Option<api::ContainerState>, writer: &mut ClickWri
             } else if let Some(waiting) = state.waiting.as_ref() {
                 let message = waiting.message.as_deref().unwrap_or("no message");
                 let reason = waiting.reason.as_deref().unwrap_or("no reason");
-                clickwrite!(writer, "{}\n", Yellow.paint("Waiting"));
+                clickwrite!(writer, "{}\n", styles.warning("Waiting"));
                 clickwrite!(writer, "\t\t  message: {}\n", message);
                 clickwrite!(writer, "\t\t  reason: {}\n", reason);
             } else {
                 clickwrite!(
                     writer,
                     "{}",
-                    format!("{} (reason unknown)\n", Yellow.paint("Waiting"))
+                    format!("{} (reason unknown)\n", styles.warning("Waiting"))
                 );
             }
         }

--- a/src/command/pods.rs
+++ b/src/command/pods.rs
@@ -25,7 +25,7 @@ use crate::{
     kobj::{KObj, ObjType},
     output::ClickWriter,
     styles::Styles,
-    table::CellSpec,
+    table::{CellSpec, ColorType},
 };
 
 use std::collections::HashMap;
@@ -111,16 +111,15 @@ fn has_waiting(pod: &api::Pod) -> bool {
     }
 }
 
-fn phase_style_color(phase: &str) -> comfy_table::Color {
-    use comfy_table::Color;
+fn phase_style_color(phase: &str) -> ColorType {
     match phase {
-        "Running" | "Active" => Color::DarkGreen,
-        "Terminated" | "Terminating" => Color::DarkRed,
-        "Pending" | "ContainerCreating" => Color::DarkYellow,
-        "Succeeded" => Color::DarkBlue,
-        "Failed" => Color::DarkRed,
-        "Unknown" => Color::DarkRed,
-        _ => Color::DarkRed,
+        "Running" | "Active" => ColorType::Success,
+        "Terminated" | "Terminating" => ColorType::Danger,
+        "Pending" | "ContainerCreating" => ColorType::Warn,
+        "Succeeded" => ColorType::Info,
+        "Failed" => ColorType::Danger,
+        "Unknown" => ColorType::Danger,
+        _ => ColorType::Danger,
     }
 }
 
@@ -229,7 +228,7 @@ fn pod_status(pod: &api::Pod) -> Option<CellSpec<'_>> {
             .unwrap_or("Unknown")
     };
     let fg = phase_style_color(status);
-    Some(CellSpec::with_colors(status.into(), Some(fg), None))
+    Some(CellSpec::with_colors(status.into(), Some(fg.into()), None))
 }
 
 list_command!(

--- a/src/command/portforwards.rs
+++ b/src/command/portforwards.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use comfy_table::{Cell, CellAlignment, Table};
 use rustyline::completion::Pair as RustlinePair;

--- a/src/command/replicasets.rs
+++ b/src/command/replicasets.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::api::apps::v1 as apps_api;
 

--- a/src/command/rollouts.rs
+++ b/src/command/rollouts.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 /// Support for argo rollouts https://argoproj.github.io/argo-rollouts/
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::{
     apimachinery::pkg::apis::meta::v1::ObjectMeta, http, ListOptional, ListResponse,

--- a/src/command/secrets.rs
+++ b/src/command/secrets.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::api::core::v1 as api;
 

--- a/src/command/services.rs
+++ b/src/command/services.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::api::core::v1 as api;
 

--- a/src/command/statefulsets.rs
+++ b/src/command/statefulsets.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::api::apps::v1 as apps_api;
 

--- a/src/command/storage.rs
+++ b/src/command/storage.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::api::storage::v1 as api_storage;
 

--- a/src/command/volumes.rs
+++ b/src/command/volumes.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ansi_term::Colour::Yellow;
 use clap::{Arg, Command as ClapCommand};
 use k8s_openapi::{api::core::v1 as api, apimachinery::pkg::api::resource::Quantity};
 

--- a/src/k8s_table.rs
+++ b/src/k8s_table.rs
@@ -24,6 +24,7 @@ use serde::Deserializer;
 use serde_json::Value;
 
 use crate::{
+    env::Env,
     kobj::{KObj, ObjType},
     output::ClickWriter,
     table::CellSpec,
@@ -82,6 +83,7 @@ pub struct K8sTable {
 impl K8sTable {
     pub fn print_to(
         &self,
+        env: &Env,
         show_namespace: bool,
         _type: &str,
         group_version: &str,
@@ -119,7 +121,7 @@ impl K8sTable {
                 },
             });
         }
-        crate::table::print_table(titles, rows, writer);
+        crate::table::print_table(titles, rows, env, writer);
         kobjs
     }
 }

--- a/src/kobj.rs
+++ b/src/kobj.rs
@@ -18,8 +18,6 @@ use crate::output::ClickWriter;
 use crate::values::val_str_opt;
 use crate::Env;
 
-use ansi_term::ANSIString;
-use ansi_term::Colour::{Blue, Cyan, Green, Purple, Red, Yellow};
 use clap::ArgMatches;
 use k8s_openapi::api::{
     apps::v1 as api_apps, batch::v1 as api_batch, core::v1 as api, storage::v1 as api_storage,
@@ -103,27 +101,6 @@ impl KObj {
             ObjType::StorageClass => "StorageClass",
             #[cfg(feature = "argorollouts")]
             ObjType::Rollout => "Rollout",
-        }
-    }
-
-    pub fn prompt_str(&self) -> ANSIString {
-        match self.typ {
-            ObjType::Pod { .. } => Yellow.bold().paint(self.name.as_str()),
-            ObjType::Crd { .. } => Blue.bold().paint(self.name.as_str()),
-            ObjType::Node => Blue.bold().paint(self.name.as_str()),
-            ObjType::DaemonSet => Yellow.bold().paint(self.name.as_str()),
-            ObjType::Deployment => Purple.bold().paint(self.name.as_str()),
-            ObjType::Service => Cyan.bold().paint(self.name.as_str()),
-            ObjType::ReplicaSet => Green.bold().paint(self.name.as_str()),
-            ObjType::StatefulSet => Green.bold().paint(self.name.as_str()),
-            ObjType::ConfigMap => Purple.bold().paint(self.name.as_str()),
-            ObjType::Secret => Red.bold().paint(self.name.as_str()),
-            ObjType::Job => Purple.bold().paint(self.name.as_str()),
-            ObjType::Namespace => Green.bold().paint(self.name.as_str()),
-            ObjType::PersistentVolume => Blue.bold().paint(self.name.as_str()),
-            ObjType::StorageClass => Red.bold().paint(self.name.as_str()),
-            #[cfg(feature = "argorollouts")]
-            ObjType::Rollout => Purple.bold().paint(self.name.as_str()),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,14 +23,15 @@ extern crate serde_derive;
 #[macro_use]
 mod output;
 
-extern crate ansi_term;
 extern crate atomicwrites;
 extern crate base64;
 extern crate chrono;
 #[macro_use]
 extern crate clap;
 extern crate comfy_table;
+extern crate crossterm;
 extern crate ctrlc;
+extern crate derivative;
 extern crate dirs;
 extern crate duct_sh;
 extern crate humantime;
@@ -66,6 +67,7 @@ mod k8s;
 mod k8s_table;
 mod kobj;
 mod parser;
+mod styles;
 mod table;
 mod values;
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -14,7 +14,7 @@
 
 /// Module to handle writing data to stdout, and/or copying/writing it
 /// to files etc
-use ansi_term::Colour::{Blue, Green};
+use crossterm::style::{Attribute, Color, ResetColor, SetAttribute, SetForegroundColor};
 use duct::Handle;
 use duct_sh::sh_dangerous;
 use os_pipe::{pipe, PipeWriter};
@@ -288,7 +288,7 @@ impl<'a> Formatter for PrettyColorFormatter<'a> {
         W: Write,
     {
         if self.invalue && !self.iskey {
-            write!(writer, "{}", Green.prefix()).unwrap_or(());
+            write!(writer, "{}", SetForegroundColor(Color::Green)).unwrap_or(());
         }
         self.pretty.begin_string(writer)
     }
@@ -299,7 +299,7 @@ impl<'a> Formatter for PrettyColorFormatter<'a> {
     {
         let r = self.pretty.end_string(writer);
         if self.invalue && !self.iskey {
-            write!(writer, "{}", Green.suffix()).unwrap_or(());
+            write!(writer, "{}", ResetColor).unwrap_or(());
         }
         r
     }
@@ -370,7 +370,8 @@ impl<'a> Formatter for PrettyColorFormatter<'a> {
     {
         self.iskey = true;
         let r = self.pretty.begin_object_key(writer, first);
-        write!(writer, "{}", Blue.bold().prefix()).unwrap_or(());
+        write!(writer, "{}", SetForegroundColor(Color::Blue)).unwrap_or(());
+        write!(writer, "{}", SetAttribute(Attribute::Bold)).unwrap_or(());
         r
     }
 
@@ -380,7 +381,7 @@ impl<'a> Formatter for PrettyColorFormatter<'a> {
     {
         let r = self.pretty.end_object_key(writer);
         self.iskey = false;
-        write!(writer, "{}", Blue.bold().suffix()).unwrap_or(());
+        write!(writer, "{}", ResetColor).unwrap_or(());
         r
     }
 

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -1,0 +1,114 @@
+// Copyright 2022 Databricks, Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Module that defines methods to color click output appropriately
+use crossterm::style::{Attribute, Attributes, Color, ContentStyle, StyledContent, Stylize};
+use std::collections::HashMap;
+
+pub struct Styles {
+    prompt_object_map: HashMap<&'static str, ContentStyle>,
+}
+
+macro_rules! style {
+    ($style_name:ident, $arg:ident $style_apply:block) => {
+        pub fn $style_name<'a>(&self, $arg: &'a str) -> StyledContent<&'a str> $style_apply
+    };
+}
+
+macro_rules! obj_style {
+    ($fg: expr) => {
+        ContentStyle {
+            foreground_color: Some($fg),
+            background_color: None,
+            attributes: Attributes::default(),
+        }
+    };
+    ($fg: expr, $attrs: expr) => {
+        ContentStyle {
+            foreground_color: Some($fg),
+            background_color: None,
+            attributes: $attrs,
+        }
+    };
+}
+
+lazy_static! {
+    static ref BOLD: Attributes = {
+        let mut attrs = Attributes::default();
+        attrs.set(Attribute::Bold);
+        attrs
+    };
+    static ref NOSTYLE: ContentStyle = ContentStyle::new();
+}
+
+impl Styles {
+    pub fn new() -> Styles {
+        let prompt_object_map = HashMap::from([
+            ("Pod", obj_style!(Color::Yellow, *BOLD)),
+            ("Crd", obj_style!(Color::Blue, *BOLD)),
+            ("Node", obj_style!(Color::Blue, *BOLD)),
+            ("DaemonSet", obj_style!(Color::Yellow, *BOLD)),
+            ("Deployment", obj_style!(Color::Magenta, *BOLD)),
+            ("Service", obj_style!(Color::Cyan, *BOLD)),
+            ("ReplicaSet", obj_style!(Color::Green, *BOLD)),
+            ("StatefulSet", obj_style!(Color::Green, *BOLD)),
+            ("ConfigMap", obj_style!(Color::Magenta, *BOLD)),
+            ("Secret", obj_style!(Color::Red, *BOLD)),
+            ("Job", obj_style!(Color::Magenta, *BOLD)),
+            ("PersistentVolume", obj_style!(Color::Blue, *BOLD)),
+            ("StorageClass", obj_style!(Color::Red, *BOLD)),
+            #[cfg(feature = "argorollouts")]
+            ("Rollout", obj_style!(Color::Magenta, *BOLD)),
+        ]);
+
+        Styles { prompt_object_map }
+    }
+
+    pub fn prompt_object<'a>(&self, name: &'a str, type_str: &str) -> StyledContent<&'a str> {
+        match self.prompt_object_map.get(type_str) {
+            Some(style) => style.apply(name),
+            None => NOSTYLE.apply(name),
+        }
+    }
+
+    // general colors
+    style!(success, s {s.dark_green()});
+    style!(warning, s {s.dark_yellow()});
+    style!(danger,  s {s.dark_red()});
+
+    // prompt colors
+    style!(prompt_context,     s {s.red().bold()});
+    style!(prompt_namespace,   s {s.green().bold()});
+    style!(prompt_range,       s {s.blue()});
+    style!(prompt_select_none, s {s.dark_yellow()});
+
+    // config printing colors
+    // TODO: Maybe add this
+    // style!(config_key, s {s.red()});
+    pub fn config_val_string(&self, s: String) -> StyledContent<String> {
+        s.yellow()
+    }
+    style!(config_val, s {s.yellow()});
+
+    // other colors
+    pub fn success_color(&self) -> Color { Color::DarkGreen }
+    pub fn warning_color(&self) -> Color { Color::DarkYellow }
+    pub fn danger_color(&self) -> Color { Color::DarkRed }
+    pub fn info_color(&self) -> Color { Color::DarkBlue }
+
+    pub fn context_table_color(&self) -> Color { Color::Red }
+
+    // attributes
+    style!(bold, s {s.bold()});
+}

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -102,13 +102,29 @@ impl Styles {
     style!(config_val, s {s.yellow()});
 
     // other colors
-    pub fn success_color(&self) -> Color { Color::DarkGreen }
-    pub fn warning_color(&self) -> Color { Color::DarkYellow }
-    pub fn danger_color(&self) -> Color { Color::DarkRed }
-    pub fn info_color(&self) -> Color { Color::DarkBlue }
+    pub fn success_color(&self) -> Color {
+        Color::DarkGreen
+    }
+    pub fn warning_color(&self) -> Color {
+        Color::DarkYellow
+    }
+    pub fn danger_color(&self) -> Color {
+        Color::DarkRed
+    }
+    pub fn info_color(&self) -> Color {
+        Color::DarkBlue
+    }
 
-    pub fn context_table_color(&self) -> Color { Color::Red }
+    pub fn context_table_color(&self) -> Color {
+        Color::Red
+    }
 
     // attributes
     style!(bold, s {s.bold()});
+}
+
+impl Default for Styles {
+    fn default() -> Self {
+        Self::new()
+    }
 }


### PR DESCRIPTION
This redirects all text style choices to a `Styles` module, setting the stage for turning off color and adding themes