### PR TITLE
Parse ca certs one by one, since mac reqwest doesn't seem to handle multiple in one string

### DIFF
--- a/.github/workflows/push-actions.yml
+++ b/.github/workflows/push-actions.yml
@@ -73,6 +73,20 @@ jobs:
         with:
           command: test
 
+  test_beta_osx:
+    name: Click Beta Test Suite OSX
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: beta
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/push-actions.yml
+++ b/.github/workflows/push-actions.yml
@@ -31,6 +31,20 @@ jobs:
         with:
           command: test
 
+  test_stable_osx:
+    name: Click Test Suite OSX
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
   check_beta:
     name: Click Beta Check
     runs-on: ubuntu-latest

--- a/src/config/kube.rs
+++ b/src/config/kube.rs
@@ -355,7 +355,7 @@ dcZfHeFhVYAA1IFLezEPI2PnPfMD+fQ2qLvZ46WXTeorKeDWanOB5sCJo9Px4KWl
 IjeaY8JIILTbcuPI9tl8vrGvU9oUtCG41tWW4/5ODFlitppK+ULdjG+BqXH/9Apy
 bW1EDp3zdHSo1TRJ6V6e6bR64eVaH4QwnNOfpSXY
 -----END CERTIFICATE-----";
-    
+
     pub fn get_test_config() -> Config {
         Config {
             source_file: "/tmp/test.conf".to_string(),

--- a/src/config/kube.rs
+++ b/src/config/kube.rs
@@ -328,6 +328,34 @@ pub mod tests {
     use super::*;
     use std::collections::BTreeMap;
 
+    static TEST_CA_CERTS: &str = r"-----BEGIN CERTIFICATE-----
+MIICNDCCAaECEAKtZn5ORf5eV288mBle3cAwDQYJKoZIhvcNAQECBQAwXzELMAkG
+A1UEBhMCVVMxIDAeBgNVBAoTF1JTQSBEYXRhIFNlY3VyaXR5LCBJbmMuMS4wLAYD
+VQQLEyVTZWN1cmUgU2VydmVyIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTk0
+MTEwOTAwMDAwMFoXDTEwMDEwNzIzNTk1OVowXzELMAkGA1UEBhMCVVMxIDAeBgNV
+BAoTF1JTQSBEYXRhIFNlY3VyaXR5LCBJbmMuMS4wLAYDVQQLEyVTZWN1cmUgU2Vy
+dmVyIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MIGbMA0GCSqGSIb3DQEBAQUAA4GJ
+ADCBhQJ+AJLOesGugz5aqomDV6wlAXYMra6OLDfO6zV4ZFQD5YRAUcm/jwjiioII
+0haGN1XpsSECrXZogZoFokvJSyVmIlZsiAeP94FZbYQHZXATcXY+m3dM41CJVphI
+uR2nKRoTLkoRWZweFdVJVCxzOmmCsZc5nG1wZ0jl3S3WyB57AgMBAAEwDQYJKoZI
+hvcNAQECBQADfgBl3X7hsuyw4jrg7HFGmhkRuNPHoLQDQCYCPgmc4RKz0Vr2N6W3
+YQO2WxZpO8ZECAyIUwxrl0nHPjXcbLm7qt9cuzovk2C2qUtN8iD3zV9/ZHuO3ABc
+1/p3yjkWWW8O6tO1g39NTUJWdrTJXwT4OPjr0l91X817/OWOgHz8UA==
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIB+jCCAWMCAgGjMA0GCSqGSIb3DQEBBAUAMEUxCzAJBgNVBAYTAlVTMRgwFgYD
+VQQKEw9HVEUgQ29ycG9yYXRpb24xHDAaBgNVBAMTE0dURSBDeWJlclRydXN0IFJv
+b3QwHhcNOTYwMjIzMjMwMTAwWhcNMDYwMjIzMjM1OTAwWjBFMQswCQYDVQQGEwJV
+UzEYMBYGA1UEChMPR1RFIENvcnBvcmF0aW9uMRwwGgYDVQQDExNHVEUgQ3liZXJU
+cnVzdCBSb290MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC45k+625h8cXyv
+RLfTD0bZZOWTwUKOx7pJjTUteueLveUFMVnGsS8KDPufpz+iCWaEVh43KRuH6X4M
+ypqfpX/1FZSj1aJGgthoTNE3FQZor734sLPwKfWVWgkWYXcKIiXUT0Wqx73llt/5
+1KiOQswkwB6RJ0q1bQaAYznEol44AwIDAQABMA0GCSqGSIb3DQEBBAUAA4GBABKz
+dcZfHeFhVYAA1IFLezEPI2PnPfMD+fQ2qLvZ46WXTeorKeDWanOB5sCJo9Px4KWl
+IjeaY8JIILTbcuPI9tl8vrGvU9oUtCG41tWW4/5ODFlitppK+ULdjG+BqXH/9Apy
+bW1EDp3zdHSo1TRJ6V6e6bR64eVaH4QwnNOfpSXY
+-----END CERTIFICATE-----";
+    
     pub fn get_test_config() -> Config {
         Config {
             source_file: "/tmp/test.conf".to_string(),
@@ -361,5 +389,12 @@ pub mod tests {
         let conf = get_config_from_kubefile_test_conf();
         let click_conf = crate::config::click::tests::get_parsed_test_click_config();
         assert!(conf.get_context("c1ctx", &click_conf).is_err()); // don't have certs
+    }
+
+    #[test]
+    fn parse_multiple_certs() {
+        let certs = get_reqwest_cert(TEST_CA_CERTS);
+        assert!(certs.is_ok());
+        //assert!(certs.unwrap().len() == 2);
     }
 }


### PR DESCRIPTION
This will fix https://github.com/databricks/click/issues/195. Reqwest on osx seems to not support parsing multiple certs in one string, so we split them up and add them one at a time.