### PR TITLE
Implementation of "last" command

### DIFF
--- a/src/command/click.rs
+++ b/src/command/click.rs
@@ -176,6 +176,8 @@ command!(
     |_, env, writer| {
         if let Some(table) = env.get_last_table() {
             clickwriteln!(writer, "{table}");
+        } else {
+            clickwriteln!(writer, "no last objects to display");
         }
         Ok(())
     }

--- a/src/command/click.rs
+++ b/src/command/click.rs
@@ -14,7 +14,7 @@
 
 use chrono::offset::Utc;
 use clap::{Arg, Command as ClapCommand};
-use comfy_table::Table;
+use comfy_table::{Cell, CellAlignment, Table};
 use rustyline::completion::Pair as RustlinePair;
 
 use crate::{
@@ -161,6 +161,32 @@ command!(
             Ok(())
         })?;
         crate::table::print_filled_table(&mut table, writer);
+        Ok(())
+    }
+);
+
+command!(
+    Last,
+    "last",
+    "List target objects from the last executed query",
+    identity,
+    vec!["last"],
+    noop_complete!(),
+    no_named_complete!(),
+    |_, env, writer| {
+        let mut table = Table::new();
+        table.set_header(vec!["####", "Name", "Type", "Namespace"]);
+        if let Some(objs) = env.get_last_objs() {
+            for (idx, obj) in objs.iter().enumerate() {
+                table.add_row(vec![
+                    Cell::new(idx).set_alignment(CellAlignment::Right),
+                    Cell::new(obj.name()),
+                    Cell::new(obj.type_str()),
+                    Cell::new(obj.namespace.as_deref().unwrap_or("")),
+                ]);
+            }
+            crate::table::print_filled_table(&mut table, writer);
+        }
         Ok(())
     }
 );

--- a/src/command/click.rs
+++ b/src/command/click.rs
@@ -14,7 +14,7 @@
 
 use chrono::offset::Utc;
 use clap::{Arg, Command as ClapCommand};
-use comfy_table::{Cell, CellAlignment, Table};
+use comfy_table::Table;
 use rustyline::completion::Pair as RustlinePair;
 
 use crate::{
@@ -174,18 +174,8 @@ command!(
     noop_complete!(),
     no_named_complete!(),
     |_, env, writer| {
-        let mut table = Table::new();
-        table.set_header(vec!["####", "Name", "Type", "Namespace"]);
-        if let Some(objs) = env.get_last_objs() {
-            for (idx, obj) in objs.iter().enumerate() {
-                table.add_row(vec![
-                    Cell::new(idx).set_alignment(CellAlignment::Right),
-                    Cell::new(obj.name()),
-                    Cell::new(obj.type_str()),
-                    Cell::new(obj.namespace.as_deref().unwrap_or("")),
-                ]);
-            }
-            crate::table::print_filled_table(&mut table, writer);
+        if let Some(table) = env.get_last_table() {
+            clickwriteln!(writer, "{table}");
         }
         Ok(())
     }

--- a/src/command/crds.rs
+++ b/src/command/crds.rs
@@ -111,7 +111,7 @@ command!(
                             &desc.group_version,
                             writer,
                         );
-                        env.set_last_objs(kobjs);
+                        env.set_last_objs(kobjs, None);
                     }
                     GetTableResponse::Other(_) => println!("Other error"),
                 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -247,8 +247,8 @@ where
         specs.into_iter().unzip()
     };
 
-    crate::table::print_table(titles, rows, env, writer);
-    env.set_last_objs(kobjs);
+    let table = crate::table::print_table(titles, rows, env, writer);
+    env.set_last_objs(kobjs, Some(table));
     Ok(())
 }
 

--- a/src/command_processor.rs
+++ b/src/command_processor.rs
@@ -181,6 +181,7 @@ impl CommandProcessor {
             Box::new(crate::command::click::EnvCmd::new()),
             Box::new(crate::command::click::Quit::new()),
             Box::new(crate::command::click::Range::new()),
+            Box::new(crate::command::click::Last::new()),
             Box::new(crate::command::click::SetCmd::new()),
             Box::new(crate::command::click::UnSetCmd::new()),
             Box::new(crate::command::click::UtcCmd::new()),

--- a/src/command_processor.rs
+++ b/src/command_processor.rs
@@ -685,7 +685,7 @@ Other help topics (type 'help [TOPIC]' for details)
             PathBuf::from("/tmp/click.conf"),
         );
         let nodelist = vec![make_node_kobj("ns1")];
-        env.set_last_objs(nodelist);
+        env.set_last_objs(nodelist, None);
         let mut p = CommandProcessor::new_with_commands(
             env,
             PathBuf::from("/tmp/click.test.hist"),
@@ -718,7 +718,7 @@ Other help topics (type 'help [TOPIC]' for details)
         let node3 = make_node_kobj("ns3");
         let nodelist = vec![node1, node2, node3];
 
-        env.set_last_objs(nodelist);
+        env.set_last_objs(nodelist, None);
         let mut p = CommandProcessor::new_with_commands(
             env,
             PathBuf::from("/tmp/click.test.hist"),

--- a/src/env.rs
+++ b/src/env.rs
@@ -65,6 +65,7 @@ pub struct Env {
     pub namespace: Option<String>,
     current_selection: ObjectSelection,
     last_objs: Option<Vec<KObj>>,
+    last_table: Option<comfy_table::Table>,
     pub ctrlcbool: Arc<AtomicBool>,
     port_forwards: Vec<PortForward>,
     pub prompt: String,
@@ -105,6 +106,7 @@ impl Env {
             namespace,
             current_selection: ObjectSelection::None,
             last_objs: None,
+            last_table: None,
             ctrlcbool: CTC_BOOL.clone(),
             port_forwards: Vec::new(),
             prompt: format!("[{}] [{}] [{}] > ", nones.0, nones.1, nones.2,),
@@ -245,16 +247,22 @@ impl Env {
         }
     }
 
-    pub fn set_last_objs<T: Into<Vec<KObj>>>(&mut self, objs: T) {
+    pub fn set_last_objs<T: Into<Vec<KObj>>>(
+        &mut self,
+        objs: T,
+        table: Option<comfy_table::Table>,
+    ) {
         self.last_objs = Some(objs.into());
+        self.last_table = table;
     }
 
     pub fn clear_last_objs(&mut self) {
         self.last_objs = None;
+        self.last_table = None;
     }
 
-    pub fn get_last_objs(&self) -> Option<&[KObj]> {
-        self.last_objs.as_ref().map(|objs| &objs[..])
+    pub fn get_last_table(&self) -> Option<&comfy_table::Table> {
+        self.last_table.as_ref()
     }
 
     pub fn clear_current(&mut self) {

--- a/src/env.rs
+++ b/src/env.rs
@@ -253,6 +253,10 @@ impl Env {
         self.last_objs = None;
     }
 
+    pub fn get_last_objs(&self) -> Option<&[KObj]> {
+        self.last_objs.as_ref().map(|objs| &objs[..])
+    }
+
     pub fn clear_current(&mut self) {
         self.current_selection = ObjectSelection::None;
         self.range_str = None;

--- a/src/table.rs
+++ b/src/table.rs
@@ -458,7 +458,7 @@ pub fn print_table<T: Into<comfy_table::Row>>(
     specs: Vec<Vec<CellSpec<'_>>>,
     env: &Env,
     writer: &mut ClickWriter,
-) {
+) -> comfy_table::Table {
     let mut table = comfy_table::Table::new();
     table.load_preset(UTF8_TABLE_STYLE);
     table.set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
@@ -468,6 +468,7 @@ pub fn print_table<T: Into<comfy_table::Row>>(
         table.add_row(row_vec);
     }
     clickwriteln!(writer, "{table}");
+    table
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Implementation of `last` command according to #204.

Implementation is based on `range` command and at the moment is not respecting `KObj` type. So for example if query is `jobs`

```
 ####   Name                            Completions   Duration   Age
═════════════════════════════════════════════════════════════════════════
    0   etl-fan469-cronjob-1666047600   1/1           20s        2d 16h
    1   etl-fan469-cronjob-1666134000   1/1           21s        1d 16h
    2   etl-fan469-cronjob-1666220400   1/1           28s        16h 54m
    3   etl-fan790-cronjob-1664751600   1/1           15m 50s    17d 16h
    4   etl-fan790-cronjob-1665604800   1/1           14m 59s    7d 19h
    5   etl-fan790-cronjob-1666209600   1/1           15m 53s    19h 54m
─────────────────────────────────────────────────────────────────────────
```

The `last` command will print

```
 ####   Name                            Type          Namespace
═══════════════════════════════════════════════════════════════════
    0   etl-fan469-cronjob-1666047600   StatefulSet   default
    1   etl-fan469-cronjob-1666134000   StatefulSet   default
    2   etl-fan469-cronjob-1666220400   StatefulSet   default
    3   etl-fan790-cronjob-1664751600   StatefulSet   default
    4   etl-fan790-cronjob-1665604800   StatefulSet   default
    5   etl-fan790-cronjob-1666209600   StatefulSet   default
───────────────────────────────────────────────────────────────────
```

It's possible to preserve `CellSpec`, although it's will be much more intrusive from the perspective of `Env` struct.