### PR TITLE
Fix bug for K8s API servers behind proxy

### DIFF
--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -311,7 +311,7 @@ impl Context {
     ) -> Result<http::Response<Bytes>, ClickError> {
         let (parts, body) = k8sreq.into_parts();
 
-        let url = self.endpoint.join(&parts.uri.to_string())?;
+        let url = Url::parse(&format!("{}{}", self.endpoint, parts.uri))?;
 
         let new_provider = {
             // TODO: Fix this mess


### PR DESCRIPTION
We have multiple Kubernetes servers behind a proxy and the current logic removes the URL prefix which causes a Bad Request.

For example:
According to the current logic: 
```
self.endpoint = "https://hostname/cluster-1"
parts.uri = "/api/v1/namespaces/default/pods"
// strip the cluster-1 prefix
self.endpoint.join(&parts.uri.to_string())?; // https://hostname//api/v1/namespaces/default/pods
```

The commit fixes the above situation.