### PR TITLE
Validate namespace names before setting them

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -209,7 +209,6 @@ impl Env {
                     io::stderr(),
                     "Invalid namespace name. Namespaces must be valid RFC 1123 labels (less than 64 characters, lowercase alphanumeric or '-', and start and end with an alphanumeric character)"
                 );
-                io::stdout().flush().expect("Could not flush stdout");
                 return;
             }
         }

--- a/src/env.rs
+++ b/src/env.rs
@@ -189,8 +189,30 @@ impl Env {
         }
     }
 
+    // a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character. Max length is 63.
+    fn validate_rfc_1123_label(label: &str) -> bool {
+        if label.is_empty() || label.len() > 63 {
+            return false;
+        }
+        label
+            .chars()
+            .all(|c| (c.is_ascii_lowercase() && c.is_ascii_alphanumeric()) || c == '-')
+            && label.chars().next().unwrap().is_ascii_alphanumeric()
+            && label.chars().last().unwrap().is_ascii_alphanumeric()
+    }
+
     pub fn set_namespace(&mut self, namespace: Option<&str>) {
         let mut do_clear = false;
+        if let Some(ns) = namespace {
+            if !Env::validate_rfc_1123_label(ns) {
+                clickwriteln!(
+                    io::stderr(),
+                    "Invalid namespace name. Namespaces must be valid RFC 1123 labels (less than 64 characters, lowercase alphanumeric or '-', and start and end with an alphanumeric character)"
+                );
+                io::stdout().flush().expect("Could not flush stdout");
+                return;
+            }
+        }
         if let (Some(my_ns), Some(new_ns)) = (&self.namespace, namespace) {
             if my_ns.as_str() != new_ns {
                 do_clear = true; // need to use bool since self is borrowed here


### PR DESCRIPTION
Validate the namespace name inside Environment::set_namespace

This prevents user error when copying namespace names output from other commands and pulling in e.g. control characters. We saw user confusion with errors like the below when talking to the k8s server:

```
Got unexpected status 500 Internal Server Error (Other(Ok(Some(Object {"apiVersion": String("v1"), "code": Number(500), "kind": String("Status"), "message": String("net/http: invalid header field value for \"X-Forwarded-Path\""), "metadata": Object {}, "reason": String("InternalError"), "status": String("Failure")}))), 179)
```

With this change the error message now shows upfront when setting the namespace, e.g.:

```
[dev-aws-us-west-2] [test-shard-hasnain-lakhani-spark-tls] [none] > namespace foo&
Invalid namespace name. Namespaces must be valid RFC 1123 labels (less than 64 characters, lowercase alphanumeric or '-', and start and end with an alphanumeric character)
```